### PR TITLE
Ugh, casting strikes again

### DIFF
--- a/Dumper/MappingGenerator.cpp
+++ b/Dumper/MappingGenerator.cpp
@@ -382,7 +382,7 @@ void MappingGenerator::GenerateFileHeader(StreamType& InUsmap, const std::string
 	}
 
 	/* Write compressed size */
-	WriteToStream(InUsmap, CompressedSize);
+	WriteToStream(InUsmap, static_cast<uint32>(CompressedSize));
 
 	/* Write uncompressed size */
 	WriteToStream(InUsmap, UncompressedSize);


### PR DESCRIPTION
Writing `size_t` just writes 0. Apologies for the mixup.