### PR TITLE
Update Utils.h

### DIFF
--- a/Dumper/Utils.h
+++ b/Dumper/Utils.h
@@ -547,12 +547,12 @@ inline T* FindAlignedValueInProcess(T Value, const std::string& Sectionname = ".
 	return Result;
 }
 
-template<bool bShouldRelove32BitJumps = true>
+template<bool bShouldResolve32BitJumps = true>
 inline std::pair<const void*, int32_t> IterateVTableFunctions(void** VTable, const std::function<bool(const uint8_t* Addr, int32_t Index)>& CallBackForEachFunc, int32_t NumFunctions = 0x150, int32_t OffsetFromStart = 0x0)
 {
 	[[maybe_unused]] auto Resolve32BitRelativeJump = [](const void* FunctionPtr) -> const uint8_t*
 	{
-		if constexpr (bShouldRelove32BitJumps)
+		if constexpr (bShouldResolve32BitJumps)
 		{
 			const uint8_t* Address = reinterpret_cast<const uint8_t*>(FunctionPtr);
 			if (*Address == 0xE9)


### PR DESCRIPTION
Context clues made me think that `bShouldRelove32BitJumps ` in Utils.h was supposed to be `bShouldResolve32BitJumps` this fixes that, if it was intentional simply close this PR