### PR TITLE
fix: Improve TArray::IsValid stability

### DIFF
--- a/Dumper/CppGenerator.cpp
+++ b/Dumper/CppGenerator.cpp
@@ -5035,7 +5035,7 @@ namespace UC
 
 		inline bool IsValidIndex(int32 Index) const { return Data && Index >= 0 && Index < NumElements; }
 
-		inline bool IsValid() const { return Data && NumElements > 0 && MaxElements >= NumElements; }
+		inline bool IsValid() const { return Data && NumElements > 0 && MaxElements >= NumElements && !IsBadReadPtr(Data, NumElements*sizeof(int)); }
 
 	public:
 		inline       ArrayElementType& operator[](int32 Index)       { VerifyIndex(Index); return Data[Index]; }


### PR DESCRIPTION
Using IsBadReadPtr improves stability and prevents crashes all over the place.