### PR TITLE
Fix finding ObjObjects for SNOWBREAK CZ

### DIFF
--- a/Dumper/ObjectArray.cpp
+++ b/Dumper/ObjectArray.cpp
@@ -27,7 +27,7 @@ struct FChunkedFixedUObjectArray
 		if (NumChunks > 0x14 || NumChunks < 0x1)
 			return false;
 
-		if (MaxChunks > 0x22F || MaxChunks < 0x9)
+		if (MaxChunks > 0x22F || MaxChunks < 0x6)
 			return false;
 
 		if (NumElements > MaxElements || NumChunks > MaxChunks)


### PR DESCRIPTION
If possible, even if some games obfuscate strings, it could be nice to add in case it doesn't find anything something like "%i objects are not in the root set" xref (usually lea rax), and find ObjObjects from the code itself