### PR TITLE
Update to dumpspace version 01.02.02

### DIFF
--- a/Dumper/DumpspaceGenerator.cpp
+++ b/Dumper/DumpspaceGenerator.cpp
@@ -351,6 +351,7 @@ void DumpspaceGenerator::AddMemberToStruct(DSGen::ClassHolder& Struct, const Pro
 	Member.offset = Property.GetOffset();
 	Member.size = Property.GetSize();
 	Member.memberName = Property.GetName();
+	Member.arrayDim = Property.GetArrayDim();
 
 	Struct.members.push_back(std::move(Member));
 }

--- a/Dumper/ExternalDependencies/Dumpspace/DSGen.cpp
+++ b/Dumper/ExternalDependencies/Dumpspace/DSGen.cpp
@@ -46,7 +46,7 @@ DSGen::MemberType DSGen::createMemberType(EType type, const std::string& typeNam
 }
 
 void DSGen::addMemberToStructOrClass(ClassHolder& classHolder, const std::string& memberName, EType type,
-	const std::string& typeName, const std::string& extendedType, int offset, int size, int bitOffset)
+	const std::string& typeName, const std::string& extendedType, int offset, int size, int arrayDim, int bitOffset)
 {
 	MemberType t;
 	t.type = type;
@@ -58,19 +58,21 @@ void DSGen::addMemberToStructOrClass(ClassHolder& classHolder, const std::string
 	m.memberName = memberName;
 	m.offset = offset;
 	m.size = size;
+	m.arrayDim = arrayDim;
 	m.bitOffset = bitOffset;
 
 	classHolder.members.push_back(m);
 }
 
 void DSGen::addMemberToStructOrClass(ClassHolder& classHolder, const std::string& memberName, const MemberType& memberType,
-	int offset, int size, int bitOffset)
+	int offset, int size, int arrayDim, int bitOffset)
 {
 	MemberDefinition m;
 	m.memberType = memberType;
 	m.memberName = memberName;
 	m.offset = offset;
 	m.size = size;
+	m.arrayDim = arrayDim;
 	m.bitOffset = bitOffset;
 
 	classHolder.members.push_back(m);
@@ -129,9 +131,9 @@ void DSGen::bakeStructOrClass(ClassHolder& classHolder)
 
 
 		if (member.bitOffset > -1)
-			jmember[member.memberName + " : 1"] = std::make_tuple(member.memberType.jsonify(), member.offset, member.size, member.bitOffset);
+			jmember[member.memberName] = std::make_tuple(member.memberType.jsonify(), member.offset, member.size, member.arrayDim, member.bitOffset);
 		else
-			jmember[member.memberName] = std::make_tuple(member.memberType.jsonify(), member.offset, member.size);
+			jmember[member.memberName] = std::make_tuple(member.memberType.jsonify(), member.offset, member.size, member.arrayDim);
 		membersArray.push_back(jmember);
 	}
 	nlohmann::json j;
@@ -153,9 +155,9 @@ void DSGen::bakeStructOrClass(ClassHolder& classHolder)
 			for (const auto& param : func.functionParams)
 				functionParams.push_back(std::make_tuple(param.first.jsonify(), param.first.reference ? "&" : "", param.second));
 
-			nlohmann::json j;
-			j[func.functionName] = std::make_tuple(func.returnType.jsonify(), functionParams, func.functionOffset, func.functionFlags);
-			classFunctions.push_back(j);
+			nlohmann::json j1;
+			j1[func.functionName] = std::make_tuple(func.returnType.jsonify(), functionParams, func.functionOffset, func.functionFlags);
+			classFunctions.push_back(j1);
 		}
 		nlohmann::json f;
 
@@ -185,14 +187,14 @@ void DSGen::dump()
 	if (directory.empty())
 		throw std::exception("Please initialize a directory first!");
 
-	constexpr auto version = 10201;
+	constexpr auto version = 10202;
 
 	auto saveToDisk = [&](const nlohmann::json& json, const std::string& fileName, bool offsetFile = false)
 	{
 		nlohmann::json j;
 		j["updated_at"] = dumpTimeStamp;
 		j["data"] = json;
-		j["version"] = 10201;
+		j["version"] = version;
 
 		if(offsetFile){
 			nlohmann::json credit;

--- a/Dumper/ExternalDependencies/Dumpspace/DSGen.h
+++ b/Dumper/ExternalDependencies/Dumpspace/DSGen.h
@@ -87,7 +87,7 @@ public:
 		int offset;
 		int bitOffset;
 		int size;
-
+		int arrayDim;
 
 	};
 
@@ -190,6 +190,7 @@ public:
 	 * \param extendedType the extended type, if any (e,g ULevel* -> *, int& -> &, or empty)
 	 * \param offset the offset of the member within the struct or class
 	 * \param size the size of the member
+	 * \param arrayDim the array dimension of the member, default 1 (int foo -> 1, int foo[123] -> 123)
 	 * \param bitOffset the bit Offset of the member, leave -1 if member has no bitOffset
 	 */
 	static void addMemberToStructOrClass(
@@ -200,6 +201,7 @@ public:
 		const std::string& extendedType, 
 		int offset, 
 		int size,
+		int arrayDim = 1,
 		int bitOffset = -1
 	);
 
@@ -210,14 +212,16 @@ public:
 	 * \param memberType memberType struct
 	 * \param offset the offset of the member within the struct or class
 	 * \param size the size of the member
+	 * \param arrayDim the array dimension of the member, default 1 (int foo -> 1, int foo[123] -> 123)
 	 * \param bitOffset the bit Offset of the member, leave -1 if member has no bitOffset
 	 */
 	static void addMemberToStructOrClass(
-		ClassHolder& classHolder, 
+		ClassHolder& classHolder,
 		const std::string& memberName,
-		const MemberType& memberType, 
-		int offset, 
+		const MemberType& memberType,
+		int offset,
 		int size,
+		int arrayDim = 1,
 		int bitOffset = -1
 	);
 


### PR DESCRIPTION
**Please check the changed files in case I missed a function somewhere!**

In the Dumpspace update 01.02.02 the only significant change is that members now require the ``ArrayDim`` variable to properly display C-Style arrays on the website. 

In ``DumpspaceGenerator.cpp`` L 354 I added the ``Property.GetArrayDim();`` as I guessed, this should be the correct function. 

The dumper expects a default ArrayDim of 1 (not 0) for default members, and >1 for all members that are C-Style arrays.
I did not check the dumpers' logic, I just guessed that ArrayDim defaults to 1 in this dumper too.