### PR TITLE
Support for overriding the layout of GObjects.

### DIFF
--- a/Dumper/CppGenerator.cpp
+++ b/Dumper/CppGenerator.cpp
@@ -609,7 +609,8 @@ std::string CppGenerator::GenerateFunctions(const StructWrapper& Struct, const M
 		InHeaderFunctionText += GenerateSingleFunction(Func, StructName, FunctionFile, ParamFile);
 	}
 
-	if (!Struct.IsUnrealStruct() || !Struct.IsClass())
+	/* Skip predefined classes, all structs and classes which don't inherit from UObject (very rare). */
+	if (!Struct.IsUnrealStruct() || !Struct.IsClass() || !Struct.GetSuper().IsValid())
 		return InHeaderFunctionText;
 
 	/* Special spacing for UClass specific functions 'StaticClass' and 'GetDefaultObj' */

--- a/Dumper/Generator.cpp
+++ b/Dumper/Generator.cpp
@@ -81,7 +81,7 @@ void Generator::InitEngineCore()
 	//InitObjectArrayDecryption([](void* ObjPtr) -> uint8* { return reinterpret_cast<uint8*>(uint64(ObjPtr) ^ 0x1B5DEAFD6B4068C); });
 
 	ObjectArray::Init();
-	FName::Init();
+	FName::Init(true);
 	Off::Init();
 	PropertySizes::Init();
 	Off::InSDK::ProcessEvent::InitPE(); //Must be at this position, relies on offsets initialized in Off::Init()

--- a/Dumper/NameArray.cpp
+++ b/Dumper/NameArray.cpp
@@ -249,8 +249,6 @@ bool NameArray::InitializeNamePool(uint8_t* NamePool)
 	constexpr uint64 CoreUObjAsUint64 = 0x6A624F5565726F43; // little endian "jbOUeroC" ["/Script/CoreUObject"]
 	constexpr uint32 NoneAsUint32 = 0x656E6F4E; // little endian "None"
 
-	constexpr int64 CoreUObjectStringLength = sizeof("/S");
-
 	uint8_t** ChunkPtr = reinterpret_cast<uint8_t**>(NamePool + Off::NameArray::ChunksStart);
 
 	// "/Script/CoreUObject"

--- a/Dumper/ObjectArray.h
+++ b/Dumper/ObjectArray.h
@@ -13,19 +13,22 @@ private:
 	friend struct FFixedUObjectArray;
 	friend class ObjectArrayValidator;
 
+	friend bool IsAddressValidGObjects(const uintptr_t, const struct FFixedUObjectArrayLayout&, int32*);
+	friend bool IsAddressValidGObjects(const uintptr_t, const struct FChunkedFixedUObjectArrayLayout&, int32*);
+
 private:
-	static uint8* GObjects;
-	static uint32 NumElementsPerChunk;
-	static uint32 SizeOfFUObjectItem;
-	static uint32 FUObjectItemInitialOffset;
+	static inline uint8* GObjects = nullptr;
+	static inline uint32 NumElementsPerChunk = 0x10000;
+	static inline uint32 SizeOfFUObjectItem = 0x18;
+	static inline uint32 FUObjectItemInitialOffset = 0x0;
 
 public:
-	static std::string DecryptionLambdaStr;
+	static inline std::string DecryptionLambdaStr;
 
 private:
 	static inline void*(*ByIndex)(void* ObjectsArray, int32 Index, uint32 FUObjectItemSize, uint32 FUObjectItemOffset, uint32 PerChunk) = nullptr;
 
-	static inline uint8_t* (*DecryptPtr)(void* ObjPtr) = [](void* Ptr) -> uint8* { return (uint8*)Ptr; };
+	static inline uint8_t* (*DecryptPtr)(void* ObjPtr) = [](void* Ptr) -> uint8* { return static_cast<uint8*>(Ptr); };
 
 private:
 	static void InitializeFUObjectItem(uint8_t* FirstItemPtr);

--- a/Dumper/OffsetFinder.h
+++ b/Dumper/OffsetFinder.h
@@ -87,7 +87,10 @@ namespace OffsetFinder
 				* And we already know Name isn't at the location it's supposed to be (right after 'Class'). 'Name' must be in this space.
 				*/
 				if ((ClassOffset - IndexOffset) >= 0x4)
+				{
+					Settings::Internal::bIsObjectNameBeforeClass = true;
 					return IndexOffset + 0x4;
+				}
 
 				/* The 'Name' isn't before 'Class' and right after 'Class' is 'Outer'. So the best bet for the pos is right after 'Outer'. */
 				return ClassOffset + 0x10;
@@ -170,7 +173,8 @@ namespace OffsetFinder
 		const int32 FNameFirstInt /* ComparisonIndex */ =  *reinterpret_cast<const int32*>(NameAddress);
 		const int32 FNameSecondInt /* [Number/DisplayIndex] */ = *reinterpret_cast<const int32*>(NameAddress + 0x4);
 
-		const int32 FNameSize = Off::UObject::Outer - Off::UObject::Name;
+		/* Some games move 'Name' before 'Class'. Just substract the offset of 'Name' with the offset of the member that follows right after it, to get an estimate of sizeof(FName). */
+		const int32 FNameSize = !Settings::Internal::bIsObjectNameBeforeClass ? (Off::UObject::Outer - Off::UObject::Name) : (Off::UObject::Class - Off::UObject::Name);
 
 		Off::FName::CompIdx = 0x0;
 		Off::FName::Number = 0x4; // defaults for check

--- a/Dumper/OffsetFinder.h
+++ b/Dumper/OffsetFinder.h
@@ -54,10 +54,10 @@ namespace OffsetFinder
 	/* UObject */
 	inline void InitUObjectOffsets()
 	{
-		uint8_t* ObjA = (uint8_t*)ObjectArray::GetByIndex(0x55).GetAddress();
-		uint8_t* ObjB = (uint8_t*)ObjectArray::GetByIndex(0x123).GetAddress();
+		uint8_t* ObjA = static_cast<uint8_t*>(ObjectArray::GetByIndex(0x055).GetAddress());
+		uint8_t* ObjB = static_cast<uint8_t*>(ObjectArray::GetByIndex(0x123).GetAddress());
 
-		auto GetIndexOffset = [&ObjA, &ObjB]() -> int32_t
+		auto GetIndexOffset = [ObjA, ObjB]() -> int32_t
 		{
 			std::vector<std::pair<void*, int32_t>> Infos;
 
@@ -67,20 +67,52 @@ namespace OffsetFinder
 			return FindOffset<4>(Infos, 0x0);
 		};
 
+		auto GetNameOffset = [ObjA, ObjB](int32_t ClassOffset, int32_t IndexOffset) -> int32_t
+		{
+			const uintptr_t ObjAValueAfterClassAsPtr = *reinterpret_cast<uintptr_t*>(ObjA + ClassOffset + sizeof(void*));
+			const uintptr_t ObjBValueAfterClassAsPtr = *reinterpret_cast<uintptr_t*>(ObjB + ClassOffset + sizeof(void*));
+
+			const bool bIsObjAOuterRightAfterClass = (!IsBadReadPtr(ObjAValueAfterClassAsPtr) || ObjAValueAfterClassAsPtr == NULL);
+			const bool bIsObjBOuterRightAfterClass = (!IsBadReadPtr(ObjBValueAfterClassAsPtr) || ObjBValueAfterClassAsPtr == NULL);
+
+			/* 
+			* This check is mostly based on the assumption that FNames typically aren't valid pointers by chance.
+			* 
+			* UObjects however always have a valid name (that isn't None, and hence isn't 0).
+			*/
+			if (bIsObjAOuterRightAfterClass && bIsObjBOuterRightAfterClass)
+			{
+				/*
+				* There is "free" space between the 'Index' and 'Class', when there shouldn't be. 
+				* And we already know Name isn't at the location it's supposed to be (right after 'Class'). 'Name' must be in this space.
+				*/
+				if ((ClassOffset - IndexOffset) >= 0x4)
+					return IndexOffset + 0x4;
+
+				/* The 'Name' isn't before 'Class' and right after 'Class' is 'Outer'. So the best bet for the pos is right after 'Outer'. */
+				return ClassOffset + 0x10;
+			}
+
+			return ClassOffset + sizeof(void*);
+		};
+
 		Off::UObject::Vft = 0x00;
 		Off::UObject::Flags = sizeof(void*);
 		Off::UObject::Index = GetIndexOffset();
 		Off::UObject::Class = GetValidPointerOffset(ObjA, ObjB, Off::UObject::Index + sizeof(int), 0x40);
-		Off::UObject::Name = Off::UObject::Class + sizeof(void*);
-		Off::UObject::Outer = GetValidPointerOffset(ObjA, ObjB, Off::UObject::Name + 0x8, 0x40);
+		Off::UObject::Name = GetNameOffset(Off::UObject::Class, Off::UObject::Index); // Off::UObject::Class + sizeof(void*);
+		Off::UObject::Outer = OffsetNotFound;
+
+		/* Some games move 'Name' before 'Class', so just select the higher one for searching for 'Outer'. */
+		const int32 OuterSearchBase = max(Off::UObject::Name, Off::UObject::Class) + 0x8;
 
 		// loop a few times in case we accidentally choose a UPackage (which doesn't have an Outer) to find Outer
 		while (Off::UObject::Outer == OffsetNotFound)
 		{
-			ObjA = (uint8*)ObjectArray::GetByIndex(rand() % 0x400).GetAddress();
-			ObjB = (uint8*)ObjectArray::GetByIndex(rand() % 0x400).GetAddress();
+			Off::UObject::Outer = GetValidPointerOffset(ObjA, ObjB, OuterSearchBase, 0x40);
 
-			Off::UObject::Outer = GetValidPointerOffset(ObjA, ObjB, Off::UObject::Name + 0x8, 0x40);
+			ObjA = static_cast<uint8*>(ObjectArray::GetByIndex(rand() % 0x400).GetAddress());
+			ObjB = static_cast<uint8*>(ObjectArray::GetByIndex(rand() % 0x400).GetAddress());
 		}
 	}
 

--- a/Dumper/Offsets.cpp
+++ b/Dumper/Offsets.cpp
@@ -117,6 +117,8 @@ void Off::InSDK::Text::InitTextOffsets()
 
 	for (UEProperty Prop : Conv_StringToText.GetProperties())
 	{
+		std::cout << "Prop: " << Prop.GetName() << std::endl;
+
 		/* Func has 2 params, if the param is the return value assign to ReturnProp, else InStringProp*/
 		(Prop.HasPropertyFlags(EPropertyFlags::ReturnParm) ? ReturnProp : InStringProp) = Prop;
 	}

--- a/Dumper/Offsets.cpp
+++ b/Dumper/Offsets.cpp
@@ -117,8 +117,6 @@ void Off::InSDK::Text::InitTextOffsets()
 
 	for (UEProperty Prop : Conv_StringToText.GetProperties())
 	{
-		std::cout << "Prop: " << Prop.GetName() << std::endl;
-
 		/* Func has 2 params, if the param is the return value assign to ReturnProp, else InStringProp*/
 		(Prop.HasPropertyFlags(EPropertyFlags::ReturnParm) ? ReturnProp : InStringProp) = Prop;
 	}

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -97,6 +97,8 @@ R"(
 		/* Whether this games' engine version uses FNamePool rather than TNameEntryArray */
 		inline bool bUseNamePool = false;
 
+		/* Whether UObject::Name or UObject::Class is first. Affects the calculation of the size of FName in fixup code. Not used after Off::Init(); */
+		inline bool bIsObjectNameBeforeClass = false;
 
 		/* Whether this games uses case-sensitive FNames, adding int32 DisplayIndex to FName */
 		inline bool bUseCasePreservingName = false;

--- a/Dumper/StructManager.cpp
+++ b/Dumper/StructManager.cpp
@@ -66,8 +66,6 @@ void StructManager::InitAlignmentsAndNames()
 		StructInfo& NewOrExistingInfo = StructInfoOverrides[Obj.GetIndex()];
 		NewOrExistingInfo.Name = UniqueNameTable.FindOrAdd(Obj.GetCppName(), !Obj.IsA(EClassCastFlags::Function)).first;
 
-		UEStruct Super = ObjAsStruct.GetSuper();
-
 		int32 MinAlignment = ObjAsStruct.GetMinAlignment();
 		int32 HighestMemberAlignment = 0x1; // starting at 0x1 when checking **all**, not just struct-properties
 
@@ -80,8 +78,11 @@ void StructManager::InitAlignmentsAndNames()
 				HighestMemberAlignment = CurrentPropertyAlignment;
 		}
 
+		/* On some strange games there are BlueprintGeneratedClass UClasses which don't inherit from UObject. */
+		const bool bHasSuperClass = static_cast<bool>(ObjAsStruct.GetSuper());
+
 		// if Class alignment is below pointer-alignment (0x8), use pointer-alignment instead, else use whichever, MinAlignment or HighestAlignment, is bigger
-		if (ObjAsStruct.IsA(EClassCastFlags::Class) && HighestMemberAlignment < DefaultClassAlignment)
+		if (ObjAsStruct.IsA(EClassCastFlags::Class) && bHasSuperClass && HighestMemberAlignment < DefaultClassAlignment)
 		{
 			NewOrExistingInfo.bUseExplicitAlignment = false;
 			NewOrExistingInfo.Alignment = DefaultClassAlignment;


### PR DESCRIPTION
New layouts for GObjects can now be added to `FFixedUObjectArrayLayouts` (for versions lower than UE4.21) and `FChunkedFixedUObjectArrayLayouts` (for versions UE4.21 and above).

Also modified dumper-code to support `UObject::Name` coming before `UObject::Class`.