### PR TITLE
fix: FFieldClass forward

### DIFF
--- a/Dumper/CppGenerator.cpp
+++ b/Dumper/CppGenerator.cpp
@@ -4244,7 +4244,7 @@ R"({
 			},
 		};
 
-		/* #ifdef WIHT_EDITORONLY_DATA */
+		/* #ifdef WITH_EDITORONLY_DATA */
 		const bool bIsWithEditorOnlyData = PropertySizes::FieldPathProperty > 0x20;
 
 		if (bIsWithEditorOnlyData)
@@ -4253,7 +4253,7 @@ R"({
 			(
 				PredefinedMember{
 					.Comment = "NOT AUTO-GENERATED PROPERTY",
-					.Type = "FFieldClass*", .Name = "InitialFieldClass", .Offset = 0x08, .Size = 0x08, .ArrayDim = 0x1, .Alignment = 0x8,
+					.Type = "class FFieldClass*", .Name = "InitialFieldClass", .Offset = 0x08, .Size = 0x08, .ArrayDim = 0x1, .Alignment = 0x8,
 					.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
 				}
 			);


### PR DESCRIPTION
adds a class forward for the InitialFieldClass inside of the FFieldPath to fix a compilation error when dumping a project with editor data.