### PR TITLE
Add *_parameters.hpp files

### DIFF
--- a/Dumper/CppGenerator.cpp
+++ b/Dumper/CppGenerator.cpp
@@ -1373,6 +1373,17 @@ void CppGenerator::GenerateSDKHeader(StreamType& SdkHpp)
 
 	PackageManager::IterateDependencies(ForEachElementCallback);
 
+	auto ForEachElementParamsCallback = [&SdkHpp](const PackageManagerIterationParams& OldParams, const PackageManagerIterationParams& NewParams, bool bIsStruct) -> void
+	{
+		PackageInfoHandle CurrentPackage = PackageManager::GetInfo(NewParams.RequiredPackage);
+
+		const bool bHasParameterStructs = CurrentPackage.HasParameterStructs();
+
+		if (bHasParameterStructs)
+			SdkHpp << std::format("#include \"SDK/{}_parameters.hpp\"\n", CurrentPackage.GetName());
+	};
+
+	PackageManager::IterateDependencies(ForEachElementParamsCallback);
 
 	WriteFileEnd(SdkHpp, EFileType::SdkHpp);
 }


### PR DESCRIPTION
It might be good to tell into the readme to use this inside a pch (precompiled header) when creating a dll project ?