### PR TITLE
Fix UObjectArray not found to log and exit

### DIFF
--- a/Dumper/ObjectArray.cpp
+++ b/Dumper/ObjectArray.cpp
@@ -323,7 +323,6 @@ void ObjectArray::Init(bool bScanAllMemory)
 	if (!bScanAllMemory)
 	{
 		ObjectArray::Init(true);
-		return;
 	}
 
 	if (!bScanAllMemory)


### PR DESCRIPTION
We dont need return to exec log "GObjects couldn't be found" and exit