### PR TITLE
Added PostRender offset getting

### DIFF
--- a/Dumper/CppGenerator.cpp
+++ b/Dumper/CppGenerator.cpp
@@ -2780,8 +2780,10 @@ namespace Offsets
 	constexpr int32 GWorld            = 0x{:08X};
 	constexpr int32 ProcessEvent      = 0x{:08X};
 	constexpr int32 ProcessEventIdx   = 0x{:08X};
+	constexpr int32 PostRender		  = 0x{:08X};
+	constexpr int32 PostRenderIdx     = 0x{:08X};
 }}
-)", Off::InSDK::ObjArray::GObjects, Off::InSDK::Name::AppendNameToString, Off::InSDK::NameArray::GNames, Off::InSDK::World::GWorld, Off::InSDK::ProcessEvent::PEOffset, Off::InSDK::ProcessEvent::PEIndex);
+)", Off::InSDK::ObjArray::GObjects, Off::InSDK::Name::AppendNameToString, Off::InSDK::NameArray::GNames, Off::InSDK::World::GWorld, Off::InSDK::ProcessEvent::PEOffset, Off::InSDK::ProcessEvent::PEIndex, Off::InSDK::PostRender::PROffset, Off::InSDK::PostRender::PRIndex);
 
 
 

--- a/Dumper/DumpspaceGenerator.cpp
+++ b/Dumper/DumpspaceGenerator.cpp
@@ -451,6 +451,8 @@ void DumpspaceGenerator::GeneratedStaticOffsets()
 	DSGen::addOffset("OFFSET_GWORLD", Off::InSDK::World::GWorld);
 	DSGen::addOffset("OFFSET_PROCESSEVENT", Off::InSDK::ProcessEvent::PEOffset);
 	DSGen::addOffset("INDEX_PROCESSEVENT", Off::InSDK::ProcessEvent::PEIndex);
+	DSGen::addOffset("OFFSET_POSTRENDER", Off::InSDK::PostRender::PROffset);
+	DSGen::addOffset("INDEX_POSTRENDER", Off::InSDK::PostRender::PRIndex);
 }
 
 void DumpspaceGenerator::Generate()

--- a/Dumper/Generator.cpp
+++ b/Dumper/Generator.cpp
@@ -85,6 +85,7 @@ void Generator::InitEngineCore()
 	Off::Init();
 	PropertySizes::Init();
 	Off::InSDK::ProcessEvent::InitPE(); //Must be at this position, relies on offsets initialized in Off::Init()
+	Off::InSDK::PostRender::InitPR();
 
 	Off::InSDK::World::InitGWorld(); //Must be at this position, relies on offsets initialized in Off::Init()
 

--- a/Dumper/Offsets.h
+++ b/Dumper/Offsets.h
@@ -18,6 +18,15 @@ namespace Off
 			void InitPE(int32 Index);
 		}
 
+		namespace PostRender
+		{
+			inline int32 PRIndex;
+			inline int32 PROffset;
+
+			void InitPR();
+			void InitPR(int32 Index);
+		}
+
 		namespace World
 		{
 			inline int32 GWorld = 0x0;

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -13,15 +13,6 @@
 
 #include "Generator.h"
 
-
-enum class EFortToastType : uint8
-{
-        Default                        = 0,
-        Subdued                        = 1,
-        Impactful                      = 2,
-        EFortToastType_MAX             = 3,
-};
-
 DWORD MainThread(HMODULE Module)
 {
 	AllocConsole();


### PR DESCRIPTION
Simple method of getting the VFT index for PostRender, but seemingly accurate from my testing.

PostRender internally does practically nothing besides call UGameViewportClient::DrawTransition. Since from my testing DrawTransition is always 1 VFT index higher than PostRender, it is trivial to find the virtual function which is essentially a redirect to the next virtual function.

PostRender and DrawTransition are typical functions to be hooked when drawing an "engine" GUI, using functions that Unreal Engine provides like K2_DrawLine, K2_DrawText, etc.