### PR TITLE
Fix exit when GObjects was not found

### DIFF
--- a/Dumper/ObjectArray.cpp
+++ b/Dumper/ObjectArray.cpp
@@ -337,7 +337,7 @@ void ObjectArray::Init(bool bScanAllMemory, const char* const ModuleName)
 		return;
 	}
 
-	if (!bScanAllMemory)
+	if (GObjects == nullptr)
 	{
 		std::cout << "\nGObjects couldn't be found!\n\n\n";
 		Sleep(3000);


### PR DESCRIPTION
When GObjects is not found during `ObjectArray::Init`, it results in a crash when trying to find an offset for UObject in `FindUObjectFlagsOffset`. This fixes exit condition.