### PR TITLE
Add CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,6 @@ MigrationBackup/
 
 # VSCode
 .vscode/
+
+# CMake
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.15...4.0)
+
+# Ninja generator does not support platform specification
+if(CMAKE_GENERATOR MATCHES "Ninja")
+    # Remove all variables related to platform
+    unset(CMAKE_GENERATOR_PLATFORM CACHE)
+    unset(CMAKE_GENERATOR_PLATFORM)
+    unset(CMAKE_VS_PLATFORM_NAME CACHE)
+    unset(CMAKE_VS_PLATFORM_NAME)
+    message(STATUS "Using Ninja generator - platform specification disabled")
+endif()
+
+project(Dumper-7 LANGUAGES CXX C)
+
+include(${CMAKE_SOURCE_DIR}/cmake/common.cmake)
+
+# Source files - automatic search for all source files
+file(GLOB_RECURSE CPP_SOURCES 
+    "Dumper/*.cpp"
+    "Dumper/*.cxx"
+    "Dumper/*.cc"
+    "Dumper/*.c"
+)
+
+add_library(${PROJECT_NAME} SHARED ${CPP_SOURCES})
+
+# Include directories
+target_include_directories(${PROJECT_NAME} PRIVATE
+# Dumper
+    ${CMAKE_SOURCE_DIR}/Dumper
+
+    # Engine
+    ${CMAKE_SOURCE_DIR}/Dumper/Engine
+    ${CMAKE_SOURCE_DIR}/Dumper/Engine/Private
+    ${CMAKE_SOURCE_DIR}/Dumper/Engine/Private/OffsetFinder
+    ${CMAKE_SOURCE_DIR}/Dumper/Engine/Private/Unreal
+
+    # Engine Public
+    ${CMAKE_SOURCE_DIR}/Dumper/Engine/Public
+    ${CMAKE_SOURCE_DIR}/Dumper/Engine/Public/OffsetFinder
+    ${CMAKE_SOURCE_DIR}/Dumper/Engine/Public/Unreal
+
+    # Generator
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator/Private
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator/Private/Generators
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator/Private/Managers
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator/Private/Wrappers
+
+    # Generator Public
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator/Public
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator/Public/Generators
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator/Public/Managers
+    ${CMAKE_SOURCE_DIR}/Dumper/Generator/Public/Wrappers
+
+    # Utils
+    ${CMAKE_SOURCE_DIR}/Dumper/Utils
+    ${CMAKE_SOURCE_DIR}/Dumper/Utils/Compression
+    ${CMAKE_SOURCE_DIR}/Dumper/Utils/Dumpspace
+    ${CMAKE_SOURCE_DIR}/Dumper/Utils/Encoding
+    ${CMAKE_SOURCE_DIR}/Dumper/Utils/Json
+)
+
+# Compiler definitions
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+    $<$<CONFIG:Debug>:_DEBUG>
+    $<$<CONFIG:Release>:NDEBUG>
+    _CONSOLE
+    WIN32
+)
+
+# Set Windows subsystem
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+    VS_GLOBAL_KEYWORD "Win32Proj"
+) 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,144 @@
+{
+    "version": 8,
+    "configurePresets": [
+        {
+            "name": "clang",
+            "displayName": "Clang",
+            "description": "Configuration using Clang compiler",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+                "CMAKE_C_COMPILER": "clang.exe",
+                "CMAKE_CXX_COMPILER": "clang++.exe",
+                "CMAKE_C_FLAGS": "-m64",
+                "CMAKE_CXX_FLAGS": "-m64"
+            }
+        },
+        {
+            "name": "clang-cl",
+            "displayName": "Clang-CL",
+            "description": "Configuration using Clang-CL compiler",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+                "CMAKE_C_COMPILER": "clang-cl.exe",
+                "CMAKE_CXX_COMPILER": "clang-cl.exe",
+                "CMAKE_C_FLAGS": "-m64",
+                "CMAKE_CXX_FLAGS": "-m64"
+            }
+        },
+        {
+            "name": "vs2022",
+            "displayName": "MSVC 2022",
+            "description": "Debug configuration using MSVC 2022 (x64)",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+                "CMAKE_C_COMPILER": "cl.exe",
+                "CMAKE_CXX_COMPILER": "cl.exe"
+            }
+        },
+        {
+            "name": "vs2019",
+            "displayName": "MSVC 2019",
+            "description": "Debug configuration using MSVC 2019 (x64)",
+            "generator": "Visual Studio 16 2019",
+            "architecture": "x64",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+                "CMAKE_C_COMPILER": "cl.exe",
+                "CMAKE_CXX_COMPILER": "cl.exe"
+            }
+        },
+        {
+            "name": "vs2017",
+            "displayName": "MSVC 2017",
+            "description": "Debug configuration using MSVC 2017 (x64)",
+            "generator": "Visual Studio 15 2017",
+            "architecture": "x64",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+                "CMAKE_C_COMPILER": "cl.exe",
+                "CMAKE_CXX_COMPILER": "cl.exe"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "clang-Release",
+            "description": "Release configuration using Clang",
+            "displayName": "Release",
+            "configurePreset": "clang",
+            "configuration": "Release"
+        },
+        {
+            "name": "clang-Debug",
+            "description": "Debug configuration using Clang",
+            "displayName": "Debug",
+            "configurePreset": "clang",
+            "configuration": "Debug"
+        },
+        {
+            "name": "clang-cl-Release",
+            "description": "Release configuration using Clang-CL",
+            "displayName": "Release",
+            "configurePreset": "clang-cl",
+            "configuration": "Release"
+        },
+        {
+            "name": "clang-cl-Debug",
+            "description": "Debug configuration using Clang-CL",
+            "displayName": "Debug",
+            "configurePreset": "clang-cl",
+            "configuration": "Debug"
+        },
+        {
+            "name": "vs2019-Release",
+            "description": "Release configuration using MSVC 2019",
+            "displayName": "Release",
+            "configurePreset": "vs2019",
+            "configuration": "Release"
+        },
+        {
+            "name": "vs2019-Debug",
+            "description": "Debug configuration using MSVC 2019",
+            "displayName": "Debug",
+            "configurePreset": "vs2019",
+            "configuration": "Debug"
+        },
+        {
+            "name": "vs2022-Release",
+            "description": "Release configuration using MSVC 2022",
+            "displayName": "Release",
+            "configurePreset": "vs2022",
+            "configuration": "Release"
+        },
+        {
+            "name": "vs2022-Debug",
+            "description": "Debug configuration using MSVC 2022",
+            "displayName": "Debug",
+            "configurePreset": "vs2022",
+            "configuration": "Debug"
+        },
+        {
+            "name": "vs2017-Release",
+            "description": "Release configuration using MSVC 2017",
+            "displayName": "Release",
+            "configurePreset": "vs2017",
+            "configuration": "Release"
+        },
+        {
+            "name": "vs2017-Debug",
+            "description": "Debug configuration using MSVC 2017",
+            "displayName": "Debug",
+            "configurePreset": "vs2017",
+            "configuration": "Debug"
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,20 +16,6 @@
             }
         },
         {
-            "name": "clang-cl",
-            "displayName": "Clang-CL",
-            "description": "Configuration using Clang-CL compiler",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
-                "CMAKE_C_COMPILER": "clang-cl.exe",
-                "CMAKE_CXX_COMPILER": "clang-cl.exe",
-                "CMAKE_C_FLAGS": "-m64",
-                "CMAKE_CXX_FLAGS": "-m64"
-            }
-        },
-        {
             "name": "vs2022",
             "displayName": "MSVC 2022",
             "description": "Debug configuration using MSVC 2022 (x64)",
@@ -82,20 +68,6 @@
             "description": "Debug configuration using Clang",
             "displayName": "Debug",
             "configurePreset": "clang",
-            "configuration": "Debug"
-        },
-        {
-            "name": "clang-cl-Release",
-            "description": "Release configuration using Clang-CL",
-            "displayName": "Release",
-            "configurePreset": "clang-cl",
-            "configuration": "Release"
-        },
-        {
-            "name": "clang-cl-Debug",
-            "description": "Debug configuration using Clang-CL",
-            "displayName": "Debug",
-            "configurePreset": "clang-cl",
             "configuration": "Debug"
         },
         {

--- a/Dumper/Engine/Private/OffsetFinder/OffsetFinder.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/OffsetFinder.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <vector>
 
 #include "OffsetFinder/OffsetFinder.h"

--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -1,4 +1,3 @@
-
 #include <format>
 
 #include "Utils.h"

--- a/Dumper/Utils/Encoding/UnicodeNames.h
+++ b/Dumper/Utils/Encoding/UnicodeNames.h
@@ -9,6 +9,8 @@
 // Tables taken from the llvm-project repository on github
 // LLVMs license: https://llvm.org/LICENSE.txt
 
+using UnicodeCharRange = std::pair<char32_t, char32_t>;
+
 template<uint32_t Size>
 class UnicodeRangeTable
 {
@@ -18,8 +20,6 @@ public:
     friend constexpr bool IsUnicodeCharXIDContinue(char32_t Character);
     friend constexpr bool IsUnicodeCharXIDContinueWithoutXIDStart(char32_t Character);
 
-private:
-    using UnicodeCharRange = std::pair<char32_t, char32_t>;
 
 private:
     std::array<UnicodeCharRange, Size> CharRanges;
@@ -42,7 +42,7 @@ private:
 
 
 // Unicode 15.1 XID_Start
-constexpr UnicodeRangeTable XIDStartRanges = {{
+constexpr UnicodeCharRange XIDStartRangesData[] = {
     { 0x0041, 0x005A },   { 0x0061, 0x007A },   { 0x00AA, 0x00AA },
     { 0x00B5, 0x00B5 },   { 0x00BA, 0x00BA },   { 0x00C0, 0x00D6 },
     { 0x00D8, 0x00F6 },   { 0x00F8, 0x02C1 },   { 0x02C6, 0x02D1 },
@@ -266,13 +266,13 @@ constexpr UnicodeRangeTable XIDStartRanges = {{
     { 0x2B740, 0x2B81D }, { 0x2B820, 0x2CEA1 }, { 0x2CEB0, 0x2EBE0 },
     { 0x2EBF0, 0x2EE5D }, { 0x2F800, 0x2FA1D }, { 0x30000, 0x3134A },
     { 0x31350, 0x323AF }
-}};
+};
 
 // Unicode 15.1 XID_Continue, excluding XID_Start
 // The Unicode Property XID_Continue is a super set of XID_Start.
 // To save Space, the table below only contains the codepoints
 // that are not also in XID_Start.
-constexpr UnicodeRangeTable XIDContinueRanges = {{
+constexpr UnicodeCharRange XIDContinueRangesData[] = {
     { 0x0030, 0x0039 },   { 0x005F, 0x005F },   { 0x00B7, 0x00B7 },
     { 0x0300, 0x036F },   { 0x0387, 0x0387 },   { 0x0483, 0x0487 },
     { 0x0591, 0x05BD },   { 0x05BF, 0x05BF },   { 0x05C1, 0x05C2 },
@@ -399,7 +399,11 @@ constexpr UnicodeRangeTable XIDContinueRanges = {{
     { 0x1E140, 0x1E149 }, { 0x1E2AE, 0x1E2AE }, { 0x1E2EC, 0x1E2F9 },
     { 0x1E4EC, 0x1E4F9 }, { 0x1E8D0, 0x1E8D6 }, { 0x1E944, 0x1E94A },
     { 0x1E950, 0x1E959 }, { 0x1FBF0, 0x1FBF9 }, { 0xE0100, 0xE01EF },
-}};
+};
+
+// Создание объектов с автоматическим вычислением размера
+constexpr UnicodeRangeTable XIDStartRanges(XIDStartRangesData);
+constexpr UnicodeRangeTable XIDContinueRanges(XIDContinueRangesData);
 
 /* Checks a character for the XID_Start property. XID_Start -> valid start character for a C++ name. */
 constexpr inline bool IsUnicodeCharXIDStart(char32_t Character)

--- a/Dumper/Utils/Encoding/UnicodeNames.h
+++ b/Dumper/Utils/Encoding/UnicodeNames.h
@@ -401,7 +401,7 @@ constexpr UnicodeCharRange XIDContinueRangesData[] = {
     { 0x1E950, 0x1E959 }, { 0x1FBF0, 0x1FBF9 }, { 0xE0100, 0xE01EF },
 };
 
-// Создание объектов с автоматическим вычислением размера
+// Create objects with automatic size calculation
 constexpr UnicodeRangeTable XIDStartRanges(XIDStartRangesData);
 constexpr UnicodeRangeTable XIDContinueRanges(XIDContinueRangesData);
 

--- a/UsingCMake.md
+++ b/UsingCMake.md
@@ -1,0 +1,99 @@
+# Using CMake with Visual Studio Code and Visual Studio
+
+This guide covers the usage of CMake in both Visual Studio Code and Visual Studio.
+
+## Table of Contents
+- [Prerequisites](#prerequisites)
+- [Installing CMake](#installing-cmake)
+- [Using CMake with Visual Studio Code](#using-cmake-with-visual-studio-code)
+- [Using CMake with Visual Studio](#using-cmake-with-visual-studio)
+- [Common CMake Commands](#common-cmake-commands)
+- [Troubleshooting](#troubleshooting)
+
+## Prerequisites
+
+Before starting with CMake, ensure you have:
+
+- A C/C++ compiler (such as MSVC, GCC, or Clang)
+    - **Usually cmake is pre-installed in every Visual Studio**
+- Git (optional, but recommended for version control)
+
+## Installing CMake
+
+### Using native installer
+1. **Download CMake**:
+    - Visit the [official CMake website](https://cmake.org/download/)
+    - Download the appropriate installer for your platform
+    - For Windows, choose the Windows x64 Installer
+
+2. **Install CMake**:
+   - Run the installer
+   - Make sure to select "Add CMake to the system PATH" during installation
+   - Choose either "Add for all users" or "Add for current user"
+
+3. **Verify Installation**:
+   - Open a terminal/command prompt
+   - Run `cmake --version`
+   - You should see the installed CMake version
+
+### Using Visual Studio installer
+
+1. **Open Visual Studio Installer**:
+    - Launch Visual Studio Installer from your desktop or Start menu
+
+2. **Choose your installed product**
+    - Choose your installed product (Build Tools or Visual Studio) and press **Modify**
+    - Go to the "Individual components" tab
+
+3. **Find and install cmake**
+    - Type "cmake" in the search box to quickly find the component
+    - Check the box for "C++ CMake tools for Windows" and/or "CMake tools for Windows"
+    - Click "Modify" to install the selected components
+
+## Using CMake with Visual Studio Code
+
+### Setup
+
+1. **Install Required Extensions**:
+   - [C/C++ Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-extension-pack)
+   - [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
+
+2. **Configure a Project**:
+   - Open a folder containing a CMakeLists.txt file
+   - VS Code should automatically detect the CMake project
+   - Click on the CMake icon in the sidebar to access CMake tools
+   - Select a compiler/kit when prompted
+
+
+## Using CMake with Visual Studio
+1. Open folder in VS
+    - Select configure preset
+    - Compile (Ctrl+B)
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"CMake not found" Error**:
+   - Make sure CMake is in your PATH
+   - Restart VS Code/Visual Studio after installing CMake
+
+2. **Compiler Not Found**:
+   - Install a C/C++ compiler
+   - Make sure the compiler is in your PATH
+   - For Visual Studio Code, select a kit manually (F1 > CMake: Select a Kit)
+
+3. **Build Errors**:
+   - Check the CMake output panel for detailed error messages
+   - Verify that all required libraries are installed
+   - Check CMakeLists.txt for errors
+
+4. **Visual Studio CMake Cache Out of Sync**:
+   - Delete the build directory and reconfigure
+   - Project > Clear CMake Cache
+
+### Getting Help
+
+- CMake Documentation: [https://cmake.org/documentation/](https://cmake.org/documentation/)
+- CMake Tools Extension Documentation: [https://vector-of-bool.github.io/docs/vscode-cmake-tools/](https://vector-of-bool.github.io/docs/vscode-cmake-tools/)
+- Visual Studio CMake Documentation: [https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio)

--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -1,0 +1,9 @@
+project(Dumper-7)
+
+# Set output directories
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+
+include(${CMAKE_SOURCE_DIR}/cmake/CompilerFlags.cmake)

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -1,0 +1,140 @@
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# Set compiler options for different compilers and build types
+
+# Common options for all compilers
+set(COMMON_CXX_FLAGS_DEBUG "")
+set(COMMON_CXX_FLAGS_RELEASE "")
+
+# Apply common flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${COMMON_CXX_FLAGS_DEBUG}")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${COMMON_CXX_FLAGS_RELEASE}")
+
+# MSVC specific options
+if(MSVC)
+    # Enable multiprocessor compilation for MSVC
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /std:c++20")
+    message(STATUS "Enabled multiprocessor compilation for MSVC")
+
+    # Disable warnings for release build only
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W0")
+    
+    # Disable specific MSVC warnings
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4819 /wd4251")
+    
+    # Enable intrinsics for XORSTR
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
+
+# Clang specific options
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Set modern C++20 standard
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
+    message(STATUS "Using Clang with C++20 standard")
+    
+    # Add warnings and optimizations
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+    
+    # Optimizations for release build
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+    
+    # Debug info for debug build
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+    
+    # Disable specific warnings that might be too noisy
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces -Wno-inconsistent-missing-override")
+    
+    # Enable colored diagnostics
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
+    
+    # Enable intrinsics for xorstr (AVX/SSE support)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2 -msse4.2")
+    
+    # Silence compile erros Unreal Engine SDK
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-class-conversion -Wno-microsoft-template-shadow -Wno-pragma-once-outside-header")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-invalid-constexpr -Wno-unused-private-field")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-bool-conversion")
+    
+    # Allow reinterpret_cast in constexpr expressions
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions")
+    
+    # Support for Microsoft ABI features
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-compatibility -fms-compatibility-version=19.29")
+    
+    # Enable invalid type conversions for compatibility
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
+    
+    # Replace -fasm-blocks to more compatibility option
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fasm")
+    
+    # Дополнительные флаги для подавления ошибок со static_cast между несвязанными типами
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-microsoft-cast")
+    
+    # Игнорирование регистра в именах файлов
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")
+    
+    # Отключение строгих проверок для заголовочных файлов
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=header-guard -Wno-error=pragma-once-outside-header")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=invalid-token-paste -Wno-ignored-attributes")
+    
+    # Отключение предупреждений о Microsoft-специфичных атрибутах
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-microsoft-enum-forward-reference -Wno-microsoft-goto")
+    
+    # Отключение ошибок сужения значений в перечислениях
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++11-narrowing -Wno-narrowing")
+    
+    # Разрешение неполных типов и C-style приведений
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-incompatible-pointer-types -Wno-incompatible-function-pointer-types")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cast-function-type -Wno-cast-qual")
+    
+    # Отключение ошибок с битовыми полями
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-bitfield-constant-conversion")
+    
+    # Отключение ошибок с FSetBitIterator
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLE_FSETBITITERATOR_DECREMENT")
+    
+    # Используем компилятор в режиме максимальной совместимости с MSVC
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fdelayed-template-parsing")
+    
+    # Специальные макросы и определения для UE4 SDK на Clang
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCLANG_WORKAROUNDS")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTRUCTURE_SIZE_PARANOIA=0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS")
+    
+    # Макросы для обхода ошибки с InvalidUseOfTDelegate
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEFINE_INVALIDUSEOFTDELEGATE")
+    
+    # Отключение стандартных проверок Clang для C++
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override -Wno-overloaded-virtual")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-dynamic-class-memaccess -Wno-unused-value")
+    
+    # Игнорирование ошибок преобразования типов, которые очень часты в UE4 SDK
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=incompatible-pointer-types")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=reinterpret-base-class")
+    
+    # Игнорирование большинства стандартных ошибок Clang при компиляции UE4 SDK
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
+
+# GCC specific options
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    # Set modern C++20 standard
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
+    message(STATUS "Using GCC with C++20 standard")
+    
+    # Add warnings and optimizations
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+    
+    # Optimizations for release build
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+    
+    # Debug info for debug build
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+    
+    # Enable intrinsics for xorstr
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2 -msse4.2")
+endif()
+
+# Print compiler flags
+message(STATUS "C++ flags: ${CMAKE_CXX_FLAGS}")
+message(STATUS "C++ flags (Debug): ${CMAKE_CXX_FLAGS_DEBUG}")
+message(STATUS "C++ flags (Release): ${CMAKE_CXX_FLAGS_RELEASE}")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -67,52 +67,52 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Replace -fasm-blocks to more compatibility option
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fasm")
     
-    # Дополнительные флаги для подавления ошибок со static_cast между несвязанными типами
+    # Additional flags to suppress errors with static_cast between unrelated types
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-microsoft-cast")
     
-    # Игнорирование регистра в именах файлов
+    # Ignore case in file names
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")
     
-    # Отключение строгих проверок для заголовочных файлов
+    # Disable strict checks for header files
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=header-guard -Wno-error=pragma-once-outside-header")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=invalid-token-paste -Wno-ignored-attributes")
     
-    # Отключение предупреждений о Microsoft-специфичных атрибутах
+    # Disable warnings about Microsoft-specific attributes
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-microsoft-enum-forward-reference -Wno-microsoft-goto")
     
-    # Отключение ошибок сужения значений в перечислениях
+    # Disable errors about narrowing conversions in enums
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++11-narrowing -Wno-narrowing")
     
-    # Разрешение неполных типов и C-style приведений
+    # Allow incomplete types and C-style casts
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-incompatible-pointer-types -Wno-incompatible-function-pointer-types")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cast-function-type -Wno-cast-qual")
     
-    # Отключение ошибок с битовыми полями
+    # Disable errors with bit fields
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-bitfield-constant-conversion")
     
-    # Отключение ошибок с FSetBitIterator
+    # Disable errors with FSetBitIterator
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLE_FSETBITITERATOR_DECREMENT")
     
-    # Используем компилятор в режиме максимальной совместимости с MSVC
+    # Use the compiler in maximum compatibility mode with MSVC
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fdelayed-template-parsing")
     
-    # Специальные макросы и определения для UE4 SDK на Clang
+    # Special macros and definitions for UE4 SDK on Clang
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCLANG_WORKAROUNDS")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTRUCTURE_SIZE_PARANOIA=0")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS")
     
-    # Макросы для обхода ошибки с InvalidUseOfTDelegate
+    # Macros to workaround InvalidUseOfTDelegate errors
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEFINE_INVALIDUSEOFTDELEGATE")
     
-    # Отключение стандартных проверок Clang для C++
+    # Disable standard Clang checks for C++
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override -Wno-overloaded-virtual")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-dynamic-class-memaccess -Wno-unused-value")
     
-    # Игнорирование ошибок преобразования типов, которые очень часты в UE4 SDK
+    # Ignore type conversion errors that are very frequent in UE4 SDK
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=incompatible-pointer-types")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=reinterpret-base-class")
     
-    # Игнорирование большинства стандартных ошибок Clang при компиляции UE4 SDK
+    # Ignore most standard Clang errors when compiling UE4 SDK
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
 
 # GCC specific options


### PR DESCRIPTION
# CMake support
## Supported compilers
- Clang
- MSVC 2017
- MSVC 2019
- MSVC 2022

**Not tested** - GNU
**Not supported yet** - Clang-cl


## Changes
1. **Removed unnecessary pragma once directives from `OffsetFinder.cpp` and `Offsets.cpp`.**
2. **Fix Clang Compilation Issue with `UnicodeRangeTable` Initialization**

    This change addresses a Clang compilation error caused by the inability to deduce the `Size` template parameter of `UnicodeRangeTable` from braced initializer lists.

- **Class Modification**: Moved `using UnicodeCharRange = std::pair<char32_t, char32_t>` from `private` to global scope for consistency and visibility.
- **Data Refactoring**: Replaced inline braced initializers with `constexpr UnicodeCharRange XIDStartRangesData[]` and `constexpr UnicodeCharRange XIDContinueRangesData[]` arrays to define the ranges.
- **Object Creation**: Updated `XIDStartRanges` and `XIDContinueRanges` to use the new arrays with `constexpr UnicodeRangeTable XIDStartRanges(XIDStartRangesData)` and `constexpr UnicodeRangeTable XIDContinueRanges(XIDContinueRangesData)`, enabling automatic size deduction.

  No changes were made to the `UnicodeRangeTable` class logic or the external interface (`IsUnicodeCharXIDStart`, `IsUnicodeCharXIDContinue`, `IsUnicodeCharXIDContinueWithoutXIDStart`).
  
3. **Add simple guide**. `UsingCMake.md`