### PR TITLE
feat: added additional reserved names

### DIFF
--- a/Dumper/Generator/Public/Managers/MemberManager.h
+++ b/Dumper/Generator/Public/Managers/MemberManager.h
@@ -250,15 +250,23 @@ public:
 		MemberNames.AddReservedName("operator");
 		MemberNames.AddReservedName("return");
 
+		/* Logical operators */
+		MemberNames.AddReservedName("if");
+    	MemberNames.AddReservedName("else");
 		MemberNames.AddReservedName("or");
 		MemberNames.AddReservedName("and");
 		MemberNames.AddReservedName("xor");
 
+		/* Additional reserved names */
 		MemberNames.AddReservedName("struct");
 		MemberNames.AddReservedName("class");
 		MemberNames.AddReservedName("for");
 		MemberNames.AddReservedName("while");
+		MemberNames.AddReservedName("switch");
+		MemberNames.AddReservedName("case");
 		MemberNames.AddReservedName("this");
+		MemberNames.AddReservedName("default");
+		MemberNames.AddReservedName("override");
 		MemberNames.AddReservedName("private");
 		MemberNames.AddReservedName("public");
 		MemberNames.AddReservedName("const");


### PR DESCRIPTION
Added additional reserved names to prevent conflicts in static_assert checks

Generated SDK with an error: 
```cpp
static_assert(offsetof(UGA_Yangyang_XuliAttack_C, switch) == 0x000570, "Member *** has a wrong offset!"
                                                    ⬆️
                                                   | logical operator “switch” causing an error |
```