### PR TITLE
Add config.ini for custom sleep timeout and SDK namespace name

### DIFF
--- a/Dumper/Dumper.vcxproj
+++ b/Dumper/Dumper.vcxproj
@@ -154,6 +154,7 @@
     <ClCompile Include="Engine\Private\OffsetFinder\Offsets.cpp" />
     <ClCompile Include="Engine\Private\Unreal\UnrealObjects.cpp" />
     <ClCompile Include="Engine\Private\Unreal\UnrealTypes.cpp" />
+    <ClCompile Include="Settings.cpp" />
     <ClCompile Include="Utils\Compression\zstd.c" />
     <ClCompile Include="Utils\Dumpspace\DSGen.cpp" />
     <ClCompile Include="Generator\Private\Generators\CppGenerator.cpp" />

--- a/Dumper/Dumper.vcxproj.filters
+++ b/Dumper/Dumper.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClCompile Include="Engine\Private\OffsetFinder\OffsetFinder.cpp">
       <Filter>Engine\Private\OffsetFinder</Filter>
     </ClCompile>
+    <ClCompile Include="Settings.cpp">
+      <Filter>Generator</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Engine">

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -1424,9 +1424,9 @@ void CppGenerator::WriteFileHead(StreamType& File, PackageInfoHandle Package, EF
 
 	File << "\n";
 
-	if constexpr (CppSettings::SDKNamespaceName)
+	if (!Settings::GlobalConfig.SDKNamespaceName.empty())
 	{
-		File << std::format("namespace {}", CppSettings::SDKNamespaceName);
+		File << std::format("namespace {}", Settings::GlobalConfig.SDKNamespaceName);
 
 		if (Type == EFileType::Parameters && CppSettings::ParamNamespaceName)
 			File << std::format("::{}", CppSettings::ParamNamespaceName);
@@ -1447,7 +1447,7 @@ void CppGenerator::WriteFileEnd(StreamType& File, EFileType Type)
 	if (Type == EFileType::SdkHpp || Type == EFileType::NameCollisionsInl || Type == EFileType::UnrealContainers || Type == EFileType::UnicodeLib)
 		return; /* No namespace or packing in SDK.hpp or NameCollisions.inl */
 
-	if constexpr (CppSettings::SDKNamespaceName || CppSettings::ParamNamespaceName)
+	if (!Settings::GlobalConfig.SDKNamespaceName.empty() || CppSettings::ParamNamespaceName)
 	{
 		if (Type != EFileType::Functions)
 			File << "\n";

--- a/Dumper/Settings.cpp
+++ b/Dumper/Settings.cpp
@@ -1,0 +1,11 @@
+#include "Settings.h"
+#include <Windows.h>
+
+void Settings::Config::Load(const char* path)
+{
+    char sdkNamespace[256] = {};
+    GetPrivateProfileStringA("Settings", "SDKNamespaceName", "SDK", sdkNamespace, sizeof(sdkNamespace), path);
+    SDKNamespaceName = sdkNamespace;
+
+    SleepTimeout = GetPrivateProfileIntA("Settings", "SleepTimeout", 1000, path);
+}

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -7,6 +7,16 @@
 
 namespace Settings
 {
+	struct Config
+	{
+		int SleepTimeout = 1000;
+		std::string SDKNamespaceName = "SDK";
+
+		void Load(const char* path);
+	};
+
+	inline Config GlobalConfig;
+
 	namespace EngineCore
 	{
 		/* A special setting to fix UEnum::Names where the type is sometimes TArray<FName> and sometimes TArray<TPair<FName, Some8ByteData>> */
@@ -26,9 +36,6 @@ namespace Settings
 	{
 		/* No prefix for files->FilePrefix = "" */
 		constexpr const char* FilePrefix = "";
-
-		/* No seperate namespace for SDK -> SDKNamespaceName = nullptr */
-		constexpr const char* SDKNamespaceName = "SDK";
 
 		/* No seperate namespace for Params -> ParamNamespaceName = nullptr */
 		constexpr const char* ParamNamespaceName = "Params";

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -31,6 +31,12 @@ DWORD MainThread(HMODULE Module)
 
 	std::cerr << "Started Generation [Dumper-7]!\n";
 
+	const char* configPath = "C:/Dumper-7/config.ini";
+	Settings::GlobalConfig.Load(configPath);
+
+	std::cout << "Sleeping for " << Settings::GlobalConfig.SleepTimeout << "ms...\n";
+	Sleep(Settings::GlobalConfig.SleepTimeout);
+
 	Generator::InitEngineCore();
 	Generator::InitInternal();
 


### PR DESCRIPTION
This PR is adding a `config.ini` file, to be able to adjust the settings without the need of recompiling.
I had two issues, I am solving with this:

1: 
Some games require to execute the SDK creation when the full game is loaded. This is no issue, if the game allows injecting the DLL anytime, but for games like Wuthering Waves, the Anti Cheat is only allowing injection in the first few seconds of the game start.
With the timeout, I can delay the SDK generation and make sure the full game is loaded.

2:
I have an in-game app which supports multiple games (see https://www.th.gl/companion-app).
I am loading multiple SDKs in this project and need to generate unique namespaces. With the config.ini, I can change the SDK name.


I put the config.ini in C:/Dumper-7, because this path is already in use by the SDKGenerationPath.