### PR TITLE
Skip invalid addresses while searching for GObjects

### DIFF
--- a/Dumper/Engine/Private/Unreal/ObjectArray.cpp
+++ b/Dumper/Engine/Private/Unreal/ObjectArray.cpp
@@ -208,6 +208,19 @@ void ObjectArray::InitializeChunkSize(uint8_t* ChunksPtr)
 	Off::InSDK::ObjArray::ChunkSize = NumElementsPerChunk;
 }
 
+bool SafeMatchesAnyLayout(auto&& MatchesAnyLayout, const auto& Layouts, uintptr_t Address)
+{
+	__try
+	{
+		return MatchesAnyLayout(Layouts, Address);
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER)
+	{
+		std::cout << "Access violation at address 0x" << std::hex << Address << std::dec << ". Skipping...\n";
+		return false; // Skip this address safely if access violation happens
+	}
+};
+
 /* We don't speak about this function... */
 void ObjectArray::Init(bool bScanAllMemory, const char* const ModuleName)
 {
@@ -268,7 +281,7 @@ void ObjectArray::Init(bool bScanAllMemory, const char* const ModuleName)
 	{
 		const uintptr_t CurrentAddress = SearchBase + i;
 
-		if (MatchesAnyLayout(FFixedUObjectArrayLayouts, CurrentAddress))
+		if (SafeMatchesAnyLayout(MatchesAnyLayout, FFixedUObjectArrayLayouts, CurrentAddress))
 		{
 			GObjects = reinterpret_cast<uint8_t*>(SearchBase + i);
 			NumElementsPerChunk = -1;
@@ -293,7 +306,7 @@ void ObjectArray::Init(bool bScanAllMemory, const char* const ModuleName)
 
 			return;
 		}
-		else if (MatchesAnyLayout(FChunkedFixedUObjectArrayLayouts, CurrentAddress))
+		else if (SafeMatchesAnyLayout(MatchesAnyLayout, FChunkedFixedUObjectArrayLayouts, CurrentAddress))
 		{
 			GObjects = reinterpret_cast<uint8_t*>(SearchBase + i);
 			NumElementsPerChunk = 0x10000;


### PR DESCRIPTION
I had the issue in games like Wuthering Waves, that the GObjects detection stopped working and the game crashed.
I found out, that it tried to read from invalid addresses first. I guess, the MatchesAnyLayout is finding multiple addresses and some of them are not what we are looking for.

This PR makes sure, that the game is not crashing and skips these invalid addresses until the correct address is found.

Maybe this could be solved in MatchesAnyLayout function too.