### PR TITLE
fix(Offsets): Filter the GActiveLogWorld when InitGWorld

### DIFF
--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -90,7 +90,7 @@ void Off::InSDK::World::InitGWorld()
 				auto ObjAddress = reinterpret_cast<uintptr_t>(Obj.GetAddress());
 				auto PossibleGWorld = reinterpret_cast<volatile uintptr_t*>(Results[0]);
 				auto CurrentValue = *PossibleGWorld;
-				for (int i = 0; CurrentValue == ObjAddress && i < 500; ++i)
+				for (int i = 0; CurrentValue == ObjAddress && i < 50; ++i)
 				{
 					::Sleep(1);
 					CurrentValue = *PossibleGWorld;

--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -87,14 +87,15 @@ void Off::InSDK::World::InitGWorld()
 			}
 			else if (Results.size() == 2)
 			{
-				auto PossibleGWorld = (volatile uintptr_t*)Results[0];
+				auto ObjAddress = reinterpret_cast<uintptr_t>(Obj.GetAddress());
+				auto PossibleGWorld = reinterpret_cast<volatile uintptr_t*>(Results[0]);
 				auto CurrentValue = *PossibleGWorld;
-				for (int i = 0; CurrentValue == (uintptr_t)Obj.GetAddress() && i < 500; ++i)
+				for (int i = 0; CurrentValue == ObjAddress && i < 500; ++i)
 				{
 					::Sleep(1);
 					CurrentValue = *PossibleGWorld;
 				}
-				if (CurrentValue == (uintptr_t)Obj.GetAddress())
+				if (CurrentValue == ObjAddress)
 				{
 					Result = Results[0];
 				}

--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -80,7 +80,8 @@ void Off::InSDK::World::InitGWorld()
 		/* Try to find a pointer to the word, aka UWorld** GWorld */
 		auto Results = FindAllAlignedValueInProcess(Obj.GetAddress());
 		void* Result = nullptr;
-		if (Results.size()) {
+		if (Results.size())
+		{
 			if (Results.size() == 1)
 			{
 				Result = Results[0];

--- a/Dumper/Utils/Utils.h
+++ b/Dumper/Utils/Utils.h
@@ -635,6 +635,53 @@ inline T* FindAlignedValueInProcess(T Value, const std::string& Sectionname = ".
 	return Result;
 }
 
+template<typename T>
+inline std::vector<T*> FindAllAlignedValueInProcess(T Value, const std::string& Sectionname = ".data", int32_t Alignment = alignof(T), bool bSearchAllSections = false)
+{
+	const auto [ImageBase, ImageSize] = GetImageBaseAndSize();
+
+	uintptr_t SearchStart = ImageBase;
+	uintptr_t SearchRange = ImageSize;
+
+	if (!bSearchAllSections)
+	{
+		const auto [SectionStart, SectionSize] = GetSectionByName(ImageBase, Sectionname);
+
+		if (SectionStart != 0x0 && SectionSize != 0x0)
+		{
+			SearchStart = SectionStart;
+			SearchRange = SectionSize;
+		}
+		else
+		{
+			bSearchAllSections = true;
+		}
+	}
+
+	std::vector<T*> Results;
+	auto Start = SearchStart;
+	auto Range = SearchRange;
+	do {
+		T* Result = FindAlignedValueInProcessInRange(Value, Alignment, Start, Range);
+		if (!Result) {
+			break;
+		}
+		Results.push_back(Result);
+		uintptr_t NewStart = reinterpret_cast<uintptr_t>(Result) + Alignment;
+		intptr_t NewRange = Range - (NewStart - Start);
+		if (NewRange < 0) {
+			break;
+		}
+		Start = NewStart;
+		Range = NewRange;
+	} while (true);
+
+	if (Results.empty() && SearchStart != ImageBase)
+		return FindAllAlignedValueInProcess(Value, Sectionname, Alignment, true);
+
+	return Results;
+}
+
 template<bool bShouldResolve32BitJumps = true>
 inline std::pair<const void*, int32_t> IterateVTableFunctions(void** VTable, const std::function<bool(const uint8_t* Addr, int32_t Index)>& CallBackForEachFunc, int32_t NumFunctions = 0x150, int32_t OffsetFromStart = 0x0)
 {

--- a/Dumper/Utils/Utils.h
+++ b/Dumper/Utils/Utils.h
@@ -661,20 +661,24 @@ inline std::vector<T*> FindAllAlignedValueInProcess(T Value, const std::string& 
 	std::vector<T*> Results;
 	auto Start = SearchStart;
 	auto Range = SearchRange;
-	do {
+	do
+	{
 		T* Result = FindAlignedValueInProcessInRange(Value, Alignment, Start, Range);
-		if (!Result) {
+		if (!Result)
+		{
 			break;
 		}
 		Results.push_back(Result);
 		uintptr_t NewStart = reinterpret_cast<uintptr_t>(Result) + Alignment;
 		intptr_t NewRange = Range - (NewStart - Start);
-		if (NewRange < 0) {
+		if (NewRange < 0)
+		{
 			break;
 		}
 		Start = NewStart;
 		Range = NewRange;
-	} while (true);
+	}
+	while (true);
 
 	if (Results.empty() && SearchStart != ImageBase)
 		return FindAllAlignedValueInProcess(Value, Sectionname, Alignment, true);


### PR DESCRIPTION
[GActiveLogWorld](https://github.com/EpicGames/UnrealEngine/blob/803688920e030c9a86c3659ac986030fba963833/Engine/Plugins/NetcodeUnitTest/NetcodeUnitTest/Source/NetcodeUnitTest/Private/Net/NUTUtilNet.cpp#L268) changes between GWorld and nullptr every tick, filter it out.