### PR TITLE
fix(Main): fclose(stderr) instead of fclose(stdout)

### DIFF
--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -75,7 +75,7 @@ DWORD MainThread(HMODULE Module)
 	{
 		if (GetAsyncKeyState(VK_F6) & 1)
 		{
-			fclose(stdout);
+			fclose(stderr);
 			if (Dummy) fclose(Dummy);
 			FreeConsole();
 


### PR DESCRIPTION
Pressing `F6` does not close the console since stderr is opened but not stdout