### PR TITLE
Replaced StaticClass() with StaticClassName() in BP classes (#379) and improved AppendString call in FName::GetRawString()

### DIFF
--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -2447,7 +2447,7 @@ R"({
 		/* non-static non-inline functions */
 		PredefinedFunction {
 			.CustomComment = "Gets a UFunction from this UClasses' 'Children' list",
-			.ReturnType = "class UFunction*", .NameWithParams = "GetFunction(const std::string& ClassName, const std::string& FuncName)", .Body =
+			.ReturnType = "class UFunction*", .NameWithParams = "GetFunction(const char* ClassName, const char* FuncName)", .Body =
 R"({
 	for(const UStruct* Clss = this; Clss; Clss = Clss->Super)
 	{

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -432,7 +432,7 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 	static class UFunction* Func = nullptr;
 
 	if (Func == nullptr)
-		Func = {}->GetFunction("{}", "{}");
+		Func = {}->GetFunction({}, {});
 {}{}{}
 	{}ProcessEvent(Func, {});{}{}{}{}
 }}
@@ -445,8 +445,8 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 , FuncInfo.FuncNameWithParams
 , bIsConstFunc ? " const" : ""
 , Func.IsStatic() ? "StaticClass()" : Func.IsInInterface() ? "AsUObject()->Class" : "Class"
-, FixedOuterName
-, FixedFunctionName
+, CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedOuterName) : std::format("\"{}\"", FixedOuterName)
+, CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedFunctionName) : std::format("\"{}\"", FixedFunctionName)
 , bHasParams ? ParamVarCreationString : ""
 , bHasParamsToInit ? ParamAssignments : ""
 , bIsNativeFunc ? StoreFunctionFlagsString : ""

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -4341,6 +4341,33 @@ R"({
 
 	FName.Functions =
 	{
+		/* constructors */
+		PredefinedFunction {
+			.CustomComment = "",
+			.ReturnType = "constexpr",
+			.NameWithParams = std::format("FName(int32 ComparisonIndex = 0{}{})",
+				!Settings::Internal::bUseOutlineNumberName ? ", uint32 Number = 0" : "",
+				Settings::Internal::bUseCasePreservingName ? ", int32 DisplayIndex = 0" : ""),
+			.Body =
+std::format(R"(	: ComparisonIndex(ComparisonIndex){}{}
+{{
+}})",
+!Settings::Internal::bUseOutlineNumberName ? ", Number(Number)" : "",
+Settings::Internal::bUseCasePreservingName ? ", DisplayIndex(DisplayIndex)" : ""),
+			.bIsStatic = false, .bIsConst = false, .bIsBodyInline = true
+		},
+		PredefinedFunction {
+			.CustomComment = "",
+			.ReturnType = "constexpr", .NameWithParams = "FName(const FName& other)",
+			.Body =
+std::format(R"(	: ComparisonIndex(other.ComparisonIndex){}{}
+{{
+}})",
+!Settings::Internal::bUseOutlineNumberName ? ", Number(other.Number)" : "",
+Settings::Internal::bUseCasePreservingName ? ", DisplayIndex(other.DisplayIndex)" : ""),
+			.bIsStatic = false, .bIsConst = false, .bIsBodyInline = true
+		},
+		/* static functions */
 		PredefinedFunction {
 			.CustomComment = "",
 			.ReturnType = "void", .NameWithParams = "InitInternal()", .Body =
@@ -4349,6 +4376,7 @@ std::format(R"({{
 }})", NameArrayName, NameArrayType, (Off::InSDK::Name::AppendNameToString == 0 && !Settings::Internal::bUseNamePool ? "*" : ""), GetNameEntryInitializationCode),
 			.bIsStatic = true, .bIsConst = false, .bIsBodyInline = true
 		},
+		/* const functions */
 		PredefinedFunction {
 			.CustomComment = "",
 			.ReturnType = "int32", .NameWithParams = "GetDisplayIndex()", .Body =
@@ -4377,6 +4405,19 @@ std::format(R"({{
 }
 )",
 			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = true
+		},
+		/* operators */
+		PredefinedFunction {
+			.CustomComment = "",
+			.ReturnType = "FName&", .NameWithParams = "operator=(const FName& other)", .Body =
+std::format(R"({{
+	ComparisonIndex = other.ComparisonIndex;{}{}
+
+	return *this;
+}})",
+!Settings::Internal::bUseOutlineNumberName ? "\n\tNumber = other.Number;" : "",
+Settings::Internal::bUseCasePreservingName ? "\n\tDisplayIndex = other.DisplayIndex;" : ""),
+			.bIsStatic = false, .bIsConst = false, .bIsBodyInline = true
 		},
 		PredefinedFunction {
 			.CustomComment = "",

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -600,7 +600,7 @@ std::string CppGenerator::GenerateFunctions(const StructWrapper& Struct, const M
 		StaticClass.Body = std::format(
 			R"({{
 	BP_STATIC_CLASS_IMPL{}({})
-}})", (!bIsNameUnique ? "" : "_FULLNAME"), NameText);
+}})", (bIsNameUnique ? "" : "_FULLNAME"), NameText);
 	}
 	else
 	{
@@ -1396,7 +1396,7 @@ void CppGenerator::WriteFileHead(StreamType& File, PackageInfoHandle Package, EF
 	{
 		File << "#include \"../PropertyFixup.hpp\"\n";
 		File << "#include \"../UnrealContainers.hpp\"\n";
-		if (Settings::CppGenerator::XORStringInclude)
+		if constexpr (Settings::CppGenerator::XORStringInclude)
 		{
 			File << std::format("#include \"{}\"\n", Settings::CppGenerator::XORStringInclude);
 		}
@@ -4475,14 +4475,14 @@ std::format(R"({{
 		/* operators */
 		PredefinedFunction {
 			.CustomComment = "",
-			.ReturnType = "FName&", .NameWithParams = "operator=(const FName& other)", .Body =
+			.ReturnType = "FName&", .NameWithParams = "operator=(const FName& Other)", .Body =
 std::format(R"({{
-	ComparisonIndex = other.ComparisonIndex;{}{}
+	ComparisonIndex = Other.ComparisonIndex;{}{}
 
 	return *this;
 }})",
-!Settings::Internal::bUseOutlineNumberName ? "\n\tNumber = other.Number;" : "",
-Settings::Internal::bUseCasePreservingName ? "\n\tDisplayIndex = other.DisplayIndex;" : ""),
+!Settings::Internal::bUseOutlineNumberName ? "\n\tNumber = Other.Number;" : "",
+Settings::Internal::bUseCasePreservingName ? "\n\tDisplayIndex = Other.DisplayIndex;" : ""),
 			.bIsStatic = false, .bIsConst = false, .bIsBodyInline = true
 		},
 		PredefinedFunction {

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -620,9 +620,9 @@ R"({{
 
 	StaticName.Body = std::format(
 R"({{
-	static FName Name = StringToName({});
+	static FName Name = FName();
 
-	return Name;
+	return GetStaticName({}, Name);
 }})", NameText);
 
 	/* Set class-specific parts of 'GetDefaultObj' */
@@ -3455,6 +3455,8 @@ namespace BasicFilesImpleUtils
 	UObject* GetObjectByIndex(int32 Index);
 
 	UFunction* FindFunctionByFName(const FName* Name);
+
+	FName StringToName(const wchar_t* Name);
 }
 )";
 
@@ -3504,16 +3506,26 @@ UFunction* BasicFilesImpleUtils::FindFunctionByFName(const FName* Name)
 
 	return nullptr;
 }
+
+FName BasicFilesImpleUtils::StringToName(const wchar_t* Name)
+{
+	return UKismetStringLibrary::Conv_StringToName(FString(Name));
+}
 )";
 
 	BasicHpp << R"(
-FName StringToName(const wchar_t* Name);
+const FName& GetStaticName(const wchar_t* Name, FName& StaticName);
 )";
 
 	BasicCpp << R"(
-FName StringToName(const wchar_t* Name)
+const FName& GetStaticName(const wchar_t* Name, FName& StaticName)
 {
-	return UKismetStringLibrary::Conv_StringToName(FString(Name));
+	if (StaticName.IsNone())
+	{
+		StaticName = BasicFilesImpleUtils::StringToName(Name);
+	}
+
+	return StaticName;
 }
 )";
 

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -3491,9 +3491,13 @@ UFunction* BasicFilesImpleUtils::FindFunctionByFName(const FName* Name)
 }
 
 )";
-
-	std::string KismetStringLibrary = CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, "KismetStringLibrary") : "\"KismetStringLibrary\"";
-	std::string Conv_StringToName = CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, "Conv_StringToName") : "\"Conv_StringToName\"";
+	std::string KismetStringLibrary = "\"KismetStringLibrary\"";
+	std::string Conv_StringToName = "\"Conv_StringToName\"";
+	if (CppSettings::XORString)
+	{
+		KismetStringLibrary = std::format("{}({})", CppSettings::XORString, KismetStringLibrary);
+		Conv_StringToName = std::format("{}({})", CppSettings::XORString, Conv_StringToName);
+	}
 
 	BasicCpp << std::format(R"(
 FName BasicFilesImpleUtils::StringToName(const wchar_t* Name)

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -4330,25 +4330,22 @@ R"({
 
 	std::string GetRawStringWithAppendString = std::format(
 		R"({{
-	thread_local wchar_t buffer[1024];
-    thread_local FString TempString(buffer, 0, 1024);
+	wchar_t buffer[1024];
+    FString TempString(buffer, 0, 1024);
 
 	if (!AppendString)
 		InitInternal();
 
 	InSDKUtils::CallGameFunction(reinterpret_cast<void({}*)(const FName*, FString&)>(AppendString), this, TempString);
 
-	std::string OutputString = TempString.ToString();
-	TempString.Clear();
-
-	return OutputString;
+	return TempString.ToString();
 }}
 )", Settings::Is32Bit() ? "__thiscall" : "");
 
 	constexpr const char* GetRawStringWithInlinedAppendString =
 		R"({
-	thread_local wchar_t buffer[1024];
-    thread_local FString TempString(buffer, 0, 1024);
+	wchar_t buffer[1024];
+    FString TempString(buffer, 0, 1024);
 
 	if (!AppendString)
 		InitInternal();
@@ -4357,7 +4354,6 @@ R"({
 	InSDKUtils::CallGameFunction(reinterpret_cast<void(*)(const void*, FString&)>(AppendString), NameEntry, TempString);
 
 	std::string OutputString = TempString.ToString();
-	TempString.Clear();
 
 	if (Number > 0)
 		OutputString += ("_" + std::to_string(Number - 1));

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -51,9 +51,10 @@ namespace Settings
 		/* No seperate namespace for Params -> ParamNamespaceName = nullptr */
 		constexpr const char* ParamNamespaceName = "Params";
 
-		/* Feature is currently not supported/not working. */
-		/* Do not XOR strings -> XORString = nullptr. Custom XorStr implementations differing from https://github.com/JustasMasiulis/xorstr may require changes to the struct 'StringLiteral' in CppGenerator.cpp.  */
+		/* XOR function name, that will be wrapped around any generated string. e.g. "xorstr_" -> xorstr_("Pawn") etc. */
 		constexpr const char* XORString = nullptr;
+		/* XOR header file name. e.g. "xorstr.hpp" */
+		constexpr const char* XORStringInclude = nullptr;
 
 		/* Customizable part of Cpp code to allow for a custom 'uintptr_t InSDKUtils::GetImageBase()' function */
 		constexpr const char* GetImageBaseFuncBody = 

--- a/UsingTheSDK.md
+++ b/UsingTheSDK.md
@@ -60,13 +60,18 @@
 ### 3. Checking a UObject's type
   - With EClassCastFlags
     ```c++
-    /* Limited to some few types, but fast */
+    /* Limited to base types, but is the fastest option */
     const bool bIsActor = Obj->IsA(EClassCastFlags::Actor);
     ```
-  - With a `UClass*`
+  - With `UClass*`
     ```c++
-    /* For every class, but slower (faster than string-comparison) */
+    /* Ideal for native classes. Use `StaticName()` for Blueprint classes instead */
     const bool bIsSpecificActor = Obj->IsA(ASomeSpecificActor::StaticClass());
+    ```
+  - With `FName` (class name)
+    ```c++
+    /* Works for every class */
+    const bool bIsSpecificActor = Obj->IsA(ASomeSpecificActor_C::StaticName());
     ```
 ### 4. Casting
   UnrealEngine heavily relies on inheritance and often uses pointers to a base class, which are later assigned addresses to \


### PR DESCRIPTION
## Changes
Main focus of the PR are changes that I suggested in #379
- Added `bool IsSubclassOf(const FName& baseClassName) const;` to compare the class by its name (FName)
- Added `bool IsA(class UClass* TypeClass) const;` to use `bool IsSubclassOf(const FName& baseClassName) const;`
- Added `StaticName()` generation for all classes
- Replaced `StaticClassImpl` and `StaticBPGeneratedClassImpl` with macros
- Added functions `GetStaticName`, `GetStaticClass` and `GetStaticBPGeneratedClass` to check and assign static variables for `StaitcClass()` and `StaticName()`
- Added `nullptr` check to `GetDefaultObjImpl()` (would crash before, if `StaticClass` returned `nullptr)`
- Added `BasicFilesImpleUtils::StringToName` which converts a `wchar_t` string to a FName with help of `UKismetStringLibrary::Conv_StringToName`
- Added `#include "Engine_classes.hpp"` to **Basic.cpp**

**Additonal changes**
- Changed `BasicFilesImpleUtils::FindClassByName` to accept `bByFullName` parameter to search by full name
- Changed the `FName::GetRawString` function to use a `wchar_t` buffer and `FString`. Stack allocation is not only faster, but it should also be safer for threads in this case, since the `free` call in `FAllocatedString`’s destructor could cause a race condition.
- Added another constructor to `FString` that allows to create a FString from a pointer, `FString(wchar_t* Str, int32 Num, int32 Max)`
- Added default constructor to `FName` that will set everything to 0 per default
- Added a copy constructor to `FName`
- Added `FName::IsNone` to check if it's a `None` name
- Added assign operator to `FName`
- Added new setting `Settings::CppGenerator::XORStringInclude` that will add a new `#include` with given file name/path to the xor header file to the `Basic.hpp`
- Changed `XORString` setting comment to explain how it works

## Implementations
### StaticClass() and StaticClassImpl()
I’ve reworked `StaticClass()` to work the old-fashioned way, where it caches the static class pointer in a local static variable. No extra compiler magic needed.
```cpp
static class UClass* StaticClass()
{
	static auto ptr = StaticClassImpl("Character");
	return ptr;
}
```
`StaticClassImpl` is now basically just a wrapper that decides at compile time if `FindClassByName` or `FindClassByFullName` is used.
I forget to test it before making the PR, since it accepts the Name string as parameter now, but any xor-string should work fine with it, since it doesn't need to know the details at compile time. Compiler inlines the whole `StaticClass()` call and any xor decryption happens before. It's important to note that the parameter type is a `char*`, it's good for xor functions which usually return a char* or wchat_t* and all the magic that converts the  `char*` to a `std::string` is done by FindClassByFullName/FindClassByName. 
```cpp
template<bool bIsFullName = false>
class UClass* StaticClassImpl(const char* Name)
{
	if constexpr (bIsFullName) {
		return BasicFilesImpleUtils::FindClassByFullName(Name);
	}
	else /* default */ {
		return BasicFilesImpleUtils::FindClassByName(Name);
	}
}
```
### StaticClassName()
Since the SDK doesn’t always use GNames, and it’s generally a hassle to convert or search for a `FName` by string, I opted for a simpler solution.
```cpp
static class FName& StaticClassName()
{
	static auto className = UKismetStringLibrary::Conv_StringToName(FString(L"BP_HDPlayerCharacterBase_C"));
	return className;
}
```
**How it works and why I think it's fine:**
The compiler inlines the StaticClassName() call.  Under normal circumstances, it never gets called until you use it as a parameter in `IsA` for the first time.  
I haven’t seen any issues with it. Also, in well-written games, it’s rare that you need to check for the topmost class, you can usually use `IsA` on the `StaticClass` of a base class.  
Xor string will work fine here as well.  
### BasicFilesImpleUtils::FindClassByName changes
I changed `FindClassByName` initially because I wanted to use it instead of `StaticClassImpl` but later decided against it.
I still find the change useful, so I left it as is.

## Postscript
The PR is open for review but shouldn’t be merged yet.
I doubt it will be approved right away, but I’m still testing it and may make some changes.  
Besides that, I would appreciate any feedback ASAP so I can work on it while it’s still fresh in my memory.

Merge of the PR will close #379