### PR TITLE
Added `CppGenerator` setting `bAddFinalSpecifier`  to control whether the `final` specifier is generated for classes marked as final #389

### DIFF
--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -684,7 +684,7 @@ void CppGenerator::GenerateStruct(const StructWrapper& Struct, StreamType& Struc
   , bIsClass ? "class" : (bIsUnion ? "union" : "struct")
   , Struct.ShouldUseExplicitAlignment() || bHasReusedTrailingPadding ? std::format("alignas(0x{:02X}) ", Struct.GetAlignment()) : ""
   , UniqueName
-  , Struct.IsFinal() ? " final" : ""
+  , Settings::CppGenerator::bAddFinalSpecifier && Struct.IsFinal() ? " final" : ""
   , bHasValidSuper ? (" : public " + UniqueSuperName) : "");
 
 	MemberManager Members = Struct.GetMembers();

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -76,6 +76,9 @@ R"(
 
 		/* This will allow the user to manually initialize global variable addresses in the SDK (eg. GObjects, GNames, AppendString). */
 		constexpr bool bAddManualOverrideOptions = true;
+
+		/* Adds the 'final' specifier to classes with no loaded child class at SDK-generation time. */
+		constexpr bool bAddFinalSpecifier = true;
 	}
 
 	namespace MappingGenerator


### PR DESCRIPTION
Closes #389