### PR TITLE
Add new settings for dump key and example config

### DIFF
--- a/Dumper/ExampleConfig/Dumper-7.ini
+++ b/Dumper/ExampleConfig/Dumper-7.ini
@@ -1,0 +1,5 @@
+[Settings]
+SleepTimeout=32
+DumpKey=0x74
+SDKGenerationPath=./
+SDKNamespaceName=SDK

--- a/Dumper/ExampleConfig/Readme.md
+++ b/Dumper/ExampleConfig/Readme.md
@@ -1,0 +1,17 @@
+### Settings file can be next to the game binary, next to the dll, or in C:/Dumper-7 and will be prioritized in that order so game local files always override
+### The file must always be named Dumper-7.ini but your dll can be named anything you want and this will still be found
+[Settings]
+### Autodump after the timeout even if you have a key set, leave on 0 or don't set it at all if you don't want this
+### Anything less than 1000 will be taken as seconds, anything more than that as ms
+SleepTimeout=0
+### Set an int value corresponding to the virtual key code you want, can be in hex or decimal, e.g. 0x77 or 119 is F8
+### You can set both a dump key and a timeout so you have the option to dump early and have a failsafe
+### Again, leave it on 0 or don't set it to ignore
+### https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+DumpKey=0x74
+### Don't set anything if you want this to go to the C:/Dumper-7 folder
+### If no drive is specified then it will be taken as a relative path
+### You can access parent paths with ../
+SDKGenerationPath=./
+### Self explanatory
+SDKNamespaceName=SDK

--- a/Dumper/Settings.cpp
+++ b/Dumper/Settings.cpp
@@ -9,127 +9,135 @@
 
 void Settings::InitWeakObjectPtrSettings()
 {
-	const UEStruct LoadAsset = ObjectArray::FindObjectFast<UEFunction>("LoadAsset", EClassCastFlags::Function);
+    const UEStruct LoadAsset = ObjectArray::FindObjectFast<UEFunction>("LoadAsset", EClassCastFlags::Function);
 
-	if (!LoadAsset)
-	{
-		std::cerr << "\nDumper-7: 'LoadAsset' wasn't found, could not determine value for 'bIsWeakObjectPtrWithoutTag'!\n" << std::endl;
-		return;
-	}
+    if (!LoadAsset)
+    {
+        std::cerr << "\nDumper-7: 'LoadAsset' wasn't found, could not determine value for 'bIsWeakObjectPtrWithoutTag'!\n" << std::endl;
+        return;
+    }
 
-	const UEProperty Asset = LoadAsset.FindMember("Asset", EClassCastFlags::SoftObjectProperty);
-	if (!Asset)
-	{
-		std::cerr << "\nDumper-7: 'Asset' wasn't found, could not determine value for 'bIsWeakObjectPtrWithoutTag'!\n" << std::endl;
-		return;
-	}
+    const UEProperty Asset = LoadAsset.FindMember("Asset", EClassCastFlags::SoftObjectProperty);
+    if (!Asset)
+    {
+        std::cerr << "\nDumper-7: 'Asset' wasn't found, could not determine value for 'bIsWeakObjectPtrWithoutTag'!\n" << std::endl;
+        return;
+    }
 
-	const UEStruct SoftObjectPath = ObjectArray::FindStructFast("SoftObjectPath");
+    const UEStruct SoftObjectPath = ObjectArray::FindStructFast("SoftObjectPath");
 
-	constexpr int32 SizeOfFFWeakObjectPtr = 0x08;
-	constexpr int32 OldUnrealAssetPtrSize = 0x10;
-	const int32 SizeOfSoftObjectPath = SoftObjectPath ? SoftObjectPath.GetStructSize() : OldUnrealAssetPtrSize;
+    constexpr int32 SizeOfFFWeakObjectPtr = 0x08;
+    constexpr int32 OldUnrealAssetPtrSize = 0x10;
+    const int32 SizeOfSoftObjectPath = SoftObjectPath ? SoftObjectPath.GetStructSize() : OldUnrealAssetPtrSize;
 
-	Settings::Internal::bIsWeakObjectPtrWithoutTag = Asset.GetSize() <= (SizeOfSoftObjectPath + SizeOfFFWeakObjectPtr);
+    Settings::Internal::bIsWeakObjectPtrWithoutTag = Asset.GetSize() <= (SizeOfSoftObjectPath + SizeOfFFWeakObjectPtr);
 
-	//std::cerr << std::format("\nDumper-7: bIsWeakObjectPtrWithoutTag = {}\n", Settings::Internal::bIsWeakObjectPtrWithoutTag) << std::endl;
+    //std::cerr << std::format("\nDumper-7: bIsWeakObjectPtrWithoutTag = {}\n", Settings::Internal::bIsWeakObjectPtrWithoutTag) << std::endl;
 }
 
 void Settings::InitLargeWorldCoordinateSettings()
 {
-	const UEStruct FVectorStruct = ObjectArray::FindStructFast("Vector");
+    const UEStruct FVectorStruct = ObjectArray::FindStructFast("Vector");
 
-	if (!FVectorStruct) [[unlikely]]
-	{
-		std::cerr << "\nSomething went horribly wrong, FVector wasn't even found!\n\n" << std::endl;
-		return;
-	}
+    if (!FVectorStruct) [[unlikely]]
+    {
+        std::cerr << "\nSomething went horribly wrong, FVector wasn't even found!\n\n" << std::endl;
+        return;
+    }
 
-	const UEProperty XProperty = FVectorStruct.FindMember("X");
+    const UEProperty XProperty = FVectorStruct.FindMember("X");
 
-	if (!XProperty) [[unlikely]]
-	{
-		std::cerr << "\nSomething went horribly wrong, FVector::X wasn't even found!\n\n" << std::endl;
-		return;
-	}
+    if (!XProperty) [[unlikely]]
+    {
+        std::cerr << "\nSomething went horribly wrong, FVector::X wasn't even found!\n\n" << std::endl;
+        return;
+    }
 
-		/* Check the underlaying type of FVector::X. If it's double we're on UE5.0, or higher, and using large world coordinates. */
-	Settings::Internal::bUseLargeWorldCoordinates = XProperty.IsA(EClassCastFlags::DoubleProperty);
+        /* Check the underlaying type of FVector::X. If it's double we're on UE5.0, or higher, and using large world coordinates. */
+    Settings::Internal::bUseLargeWorldCoordinates = XProperty.IsA(EClassCastFlags::DoubleProperty);
 
-	//std::cerr << std::format("\nDumper-7: bUseLargeWorldCoordinates = {}\n", Settings::Internal::bUseLargeWorldCoordinates) << std::endl;
+    //std::cerr << std::format("\nDumper-7: bUseLargeWorldCoordinates = {}\n", Settings::Internal::bUseLargeWorldCoordinates) << std::endl;
 }
 
 void Settings::InitObjectPtrPropertySettings()
 {
-	const UEClass ObjectPtrPropertyClass = ObjectArray::FindClassFast("ObjectPtrProperty");
+    const UEClass ObjectPtrPropertyClass = ObjectArray::FindClassFast("ObjectPtrProperty");
 
-	if (!ObjectPtrPropertyClass)
-	{
-		// The class doesn't exist, this so FieldPathProperty couldn't have been replaced with ObjectPtrProperty
-		std::cerr << std::format("\nDumper-7: bIsObjPtrInsteadOfFieldPathProperty = {}\n", Settings::Internal::bIsObjPtrInsteadOfFieldPathProperty) << std::endl;
-		Settings::Internal::bIsObjPtrInsteadOfFieldPathProperty = false;
-		return;
-	}
+    if (!ObjectPtrPropertyClass)
+    {
+        // The class doesn't exist, this so FieldPathProperty couldn't have been replaced with ObjectPtrProperty
+        std::cerr << std::format("\nDumper-7: bIsObjPtrInsteadOfFieldPathProperty = {}\n", Settings::Internal::bIsObjPtrInsteadOfFieldPathProperty) << std::endl;
+        Settings::Internal::bIsObjPtrInsteadOfFieldPathProperty = false;
+        return;
+    }
 
-	Settings::Internal::bIsObjPtrInsteadOfFieldPathProperty = ObjectPtrPropertyClass.GetDefaultObject().IsA(EClassCastFlags::FieldPathProperty);
+    Settings::Internal::bIsObjPtrInsteadOfFieldPathProperty = ObjectPtrPropertyClass.GetDefaultObject().IsA(EClassCastFlags::FieldPathProperty);
 
-	std::cerr << std::format("\nDumper-7: bIsObjPtrInsteadOfFieldPathProperty = {}\n", Settings::Internal::bIsObjPtrInsteadOfFieldPathProperty) << std::endl;
+    std::cerr << std::format("\nDumper-7: bIsObjPtrInsteadOfFieldPathProperty = {}\n", Settings::Internal::bIsObjPtrInsteadOfFieldPathProperty) << std::endl;
 }
 
 void Settings::InitArrayDimSizeSettings()
 {
-	/*
-	 * UEProperty::GetArrayDim() is already fully functional at this point.
-	 *
-	 * This setting is just there to stop it from returning (int32)0xFFFFFF01 when it should be just (uint8)0x01.
-	*/
-	for (const UEObject Obj : ObjectArray())
-	{
-		if (!Obj.IsA(EClassCastFlags::Struct))
-			continue;
+    /*
+     * UEProperty::GetArrayDim() is already fully functional at this point.
+     *
+     * This setting is just there to stop it from returning (int32)0xFFFFFF01 when it should be just (uint8)0x01.
+    */
+    for (const UEObject Obj : ObjectArray())
+    {
+        if (!Obj.IsA(EClassCastFlags::Struct))
+            continue;
 
-		const UEStruct AsStruct = Obj.Cast<UEStruct>();
+        const UEStruct AsStruct = Obj.Cast<UEStruct>();
 
-		for (const UEProperty Property : AsStruct.GetProperties())
-		{
-			// This number should just be 0x1 to indicate it's a single element, but the upper bytes aren't cleared to zero
-			if (Property.GetArrayDim() >= 0x000F0001)
-			{
-				Settings::Internal::bUseUint8ArrayDim = true;
-				std::cerr << std::format("\nDumper-7: bUseUint8ArrayDim = {}\n", Settings::Internal::bUseUint8ArrayDim) << std::endl;
-				return;
-			}
-		}
-	}
+        for (const UEProperty Property : AsStruct.GetProperties())
+        {
+            // This number should just be 0x1 to indicate it's a single element, but the upper bytes aren't cleared to zero
+            if (Property.GetArrayDim() >= 0x000F0001)
+            {
+                Settings::Internal::bUseUint8ArrayDim = true;
+                std::cerr << std::format("\nDumper-7: bUseUint8ArrayDim = {}\n", Settings::Internal::bUseUint8ArrayDim) << std::endl;
+                return;
+            }
+        }
+    }
 
-	Settings::Internal::bUseUint8ArrayDim = false;
-	std::cerr << std::format("\nDumper-7: bUseUint8ArrayDim = {}\n", Settings::Internal::bUseUint8ArrayDim) << std::endl;
+    Settings::Internal::bUseUint8ArrayDim = false;
+    std::cerr << std::format("\nDumper-7: bUseUint8ArrayDim = {}\n", Settings::Internal::bUseUint8ArrayDim) << std::endl;
 }
 
 void Settings::Config::Load()
 {
-	namespace fs = std::filesystem;
+    namespace fs = std::filesystem;
 
-	// Try local Dumper-7.ini
-	const std::string LocalPath = (fs::current_path() / "Dumper-7.ini").string();
-	const char* ConfigPath = nullptr;
+    // Check for config next to the dll itself in case we inject from a shared folder, 
+    const std::string DllPath = (fs::path(ModulePath).parent_path() / "Dumper-7.ini").string();
+    // Check for config next to the game exe, this will be the highest priority 
+    const std::string LocalPath = (fs::current_path() / "Dumper-7.ini").string();
+    const char* ConfigPath = nullptr;
 
-	if (fs::exists(LocalPath)) 
-	{
-		ConfigPath = LocalPath.c_str();
-	}
-	else if (fs::exists(GlobalConfigPath)) // Try global path
-	{
-		ConfigPath = GlobalConfigPath;
-	}
+    if (fs::exists(LocalPath)) ConfigPath = LocalPath.c_str();
+    else if (fs::exists(DllPath)) ConfigPath = DllPath.c_str();
+    else if (fs::exists(GlobalConfigPath)) ConfigPath = GlobalConfigPath;
 
-	// If no config found, use defaults
-	if (!ConfigPath) 
-		return;
 
-	char SDKNamespace[256] = {};
-	GetPrivateProfileStringA("Settings", "SDKNamespaceName", "SDK", SDKNamespace, sizeof(SDKNamespace), ConfigPath);
+    // If no config found, use defaults
+    if (!ConfigPath)
+        return;
 
-	SDKNamespaceName = SDKNamespace;
-	SleepTimeout = max(GetPrivateProfileIntA("Settings", "SleepTimeout", 0, ConfigPath), 0);
+    char SDKNamespace[256] = {};
+    GetPrivateProfileStringA("Settings", "SDKNamespaceName", "SDK", SDKNamespace, sizeof(SDKNamespace), ConfigPath);
+    SDKNamespaceName = SDKNamespace;
+    
+    // Can now specify the output path. If no drive is specified to make it absolute this will be relative to the game exe
+    char SDKPath[256] = {};
+    GetPrivateProfileStringA("Settings", "SDKGenerationPath", "C:/Dumper-7", SDKPath, sizeof(SDKPath), ConfigPath);
+    Settings::Generator::SDKGenerationPath = SDKPath;
+
+    // VK scancode ID as an Int, e.g. 0x77 or 119 = VK_F8 (yes actually type 0x77 in your ini). Otherwise defaults to 0 and is ignored
+    DumpKey = max(GetPrivateProfileIntA("Settings", "DumpKey", 0, ConfigPath), 0);
+
+    // Sleep timeout given in ms, but now we will autoadjust if the value is under 1k since we can assume they meant in seconds
+    SleepTimeout = max(GetPrivateProfileIntA("Settings", "SleepTimeout", 0, ConfigPath), 0);
+    if (SleepTimeout < 1000) SleepTimeout *= 1000;
 }

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -6,160 +6,167 @@
 
 namespace Settings
 {
-	constexpr bool Is32Bit()
-	{
+    constexpr bool Is32Bit()
+    {
 #if defined(_WIN64)
-		return false;
+        return false;
 #elif defined(_WIN32)
-		return true;
+        return true;
 #endif
-	}
+    }
   
-	inline constexpr const char* GlobalConfigPath = "C:/Dumper-7/Dumper-7.ini";
+    inline constexpr const char* GlobalConfigPath = "C:/Dumper-7/Dumper-7.ini";
 
-	namespace Config
-	{
-		inline int SleepTimeout = 0;
-		inline std::string SDKNamespaceName = "SDK";
+    namespace Config
+    {
+        /* 
+        this doesn't really need a default value since it will be set in dllmain while we have our own handle
+        this is actually just so we can check for a dll-adjacent config file without having to call GetModuleHandle("Dumper-7.dll")
+        which I chose not to do mainly because I also added a proxy loader in my fork. I could also push that over 
+        but I kind of don't want to make it that easy for people
+         */
+        inline std::string ModulePath = ".\\Dumper-7.dll";
+        inline int SleepTimeout = 0;
+        inline int DumpKey = 0;
+        inline std::string SDKNamespaceName = "SDK";
+        void Load();
+    };
 
-		void Load();
-	};
+    namespace EngineCore
+    {
+        /* A special setting to fix UEnum::Names where the type is sometimes TArray<FName> and sometimes TArray<TPair<FName, Some8BitData>> */
+        constexpr bool bCheckEnumNamesInUEnum = true;
 
-	namespace EngineCore
-	{
-		/* A special setting to fix UEnum::Names where the type is sometimes TArray<FName> and sometimes TArray<TPair<FName, Some8BitData>> */
-		constexpr bool bCheckEnumNamesInUEnum = true;
+        /* Enables support for TEncryptedObjectProperty */
+        constexpr bool bEnableEncryptedObjectPropertySupport = false;
+    }
 
-		/* Enables support for TEncryptedObjectProperty */
-		constexpr bool bEnableEncryptedObjectPropertySupport = false;
-	}
+    namespace Generator
+    {
+        //Auto generated if no override is provided
+        inline std::string GameName = "";
+        inline std::string GameVersion = "";
+        // kind of awkward not to have it in the config namespace but whatever, its fine like this I think
+        inline std::string SDKGenerationPath = "C:/Dumper-7";
+    }
 
-	namespace Generator
-	{
-		//Auto generated if no override is provided
-		inline std::string GameName = "";
-		inline std::string GameVersion = "";
+    namespace CppGenerator
+    {
+        /* No prefix for files->FilePrefix = "" */
+        constexpr const char* FilePrefix = "";
 
-		inline constexpr const char* SDKGenerationPath = "C:/Dumper-7";
-	}
+        /* No seperate namespace for Params -> ParamNamespaceName = nullptr */
+        constexpr const char* ParamNamespaceName = "Params";
 
-	namespace CppGenerator
-	{
-		/* No prefix for files->FilePrefix = "" */
-		constexpr const char* FilePrefix = "";
+        /* XOR function name, that will be wrapped around any generated string. e.g. "xorstr_" -> xorstr_("Pawn") etc. */
+        constexpr const char* XORString = nullptr;
+        /* XOR header file name. e.g. "xorstr.hpp" */
+        constexpr const char* XORStringInclude = nullptr;
 
-		/* No seperate namespace for Params -> ParamNamespaceName = nullptr */
-		constexpr const char* ParamNamespaceName = "Params";
-
-		/* XOR function name, that will be wrapped around any generated string. e.g. "xorstr_" -> xorstr_("Pawn") etc. */
-		constexpr const char* XORString = nullptr;
-		/* XOR header file name. e.g. "xorstr.hpp" */
-		constexpr const char* XORStringInclude = nullptr;
-
-		/* Customizable part of Cpp code to allow for a custom 'uintptr_t InSDKUtils::GetImageBase()' function */
-		constexpr const char* GetImageBaseFuncBody = 
+        /* Customizable part of Cpp code to allow for a custom 'uintptr_t InSDKUtils::GetImageBase()' function */
+        constexpr const char* GetImageBaseFuncBody = 
 R"({
-	return reinterpret_cast<uintptr_t>(GetModuleHandle(0));
+    return reinterpret_cast<uintptr_t>(GetModuleHandle(0));
 }
 )";
-		/* Customizable part of Cpp code to allow for a custom 'InSDKUtils::CallGameFunction' function */
-		constexpr const char* CallGameFunction =
+        /* Customizable part of Cpp code to allow for a custom 'InSDKUtils::CallGameFunction' function */
+        constexpr const char* CallGameFunction =
 R"(
-	template<typename FuncType, typename... ParamTypes>
-	requires std::invocable<FuncType, ParamTypes...>
-	inline auto CallGameFunction(FuncType Function, ParamTypes&&... Args)
-	{
-		return Function(std::forward<ParamTypes>(Args)...);
-	}
+    template<typename FuncType, typename... ParamTypes>
+    requires std::invocable<FuncType, ParamTypes...>
+    inline auto CallGameFunction(FuncType Function, ParamTypes&&... Args)
+    {
+        return Function(std::forward<ParamTypes>(Args)...);
+    }
 )";
-		/* An option to force the UWorld::GetWorld() function in the SDK to get the world through an instance of UEngine. Useful for games on which the dumper finds the wrong GWorld offset. */
-		constexpr bool bForceNoGWorldInSDK = false;
+        /* An option to force the UWorld::GetWorld() function in the SDK to get the world through an instance of UEngine. Useful for games on which the dumper finds the wrong GWorld offset. */
+        constexpr bool bForceNoGWorldInSDK = false;
 
-		/* This will allow the user to manually initialize global variable addresses in the SDK (eg. GObjects, GNames, AppendString). */
-		constexpr bool bAddManualOverrideOptions = true;
+        /* This will allow the user to manually initialize global variable addresses in the SDK (eg. GObjects, GNames, AppendString). */
+        constexpr bool bAddManualOverrideOptions = true;
 
-		/* Adds the 'final' specifier to classes with no loaded child class at SDK-generation time. */
-		constexpr bool bAddFinalSpecifier = true;
-	}
+        /* Adds the 'final' specifier to classes with no loaded child class at SDK-generation time. */
+        constexpr bool bAddFinalSpecifier = true;
+    }
 
-	namespace MappingGenerator
-	{
-		/* Whether the MappingGenerator should check if a name was written to the nametable before. Exists to reduce mapping size. */
-		constexpr bool bShouldCheckForDuplicatedNames = true;
+    namespace MappingGenerator
+    {
+        /* Whether the MappingGenerator should check if a name was written to the nametable before. Exists to reduce mapping size. */
+        constexpr bool bShouldCheckForDuplicatedNames = true;
 
-		/* Whether EditorOnly should be excluded from the mapping file. */
-		constexpr bool bExcludeEditorOnlyProperties = true;
+        /* Whether EditorOnly should be excluded from the mapping file. */
+        constexpr bool bExcludeEditorOnlyProperties = true;
 
-		/* Which compression method to use when generating the file. */
-		constexpr EUsmapCompressionMethod CompressionMethod = EUsmapCompressionMethod::ZStandard;
-	}
+        /* Which compression method to use when generating the file. */
+        constexpr EUsmapCompressionMethod CompressionMethod = EUsmapCompressionMethod::ZStandard;
+    }
 
-	/* Partially implemented  */
-	namespace Debug
-	{
-		/* Generates a dedicated file defining macros for static asserts (Make sure InlineAssertions are off) */
-		inline constexpr bool bGenerateAssertionFile = true;
+    /* Partially implemented  */
+    namespace Debug
+    {
+        /* Generates a dedicated file defining macros for static asserts (Make sure InlineAssertions are off) */
+        inline constexpr bool bGenerateAssertionFile = true;
 
-		/* Prefix for assertion macros in assertion file. Example for "MyPackage_params.hpp": #define DUMPER7_ASSERTS_PARAMS_MyPackage */
-		inline constexpr const char* AssertionMacroPrefix = "DUMPER7_ASSERTS_";
-
-
-		/* Adds static_assert for struct-size, as well as struct-alignment */
-		inline constexpr bool bGenerateInlineAssertionsForStructSize = false;
-
-		/* Adds static_assert for member-offsets */
-		inline constexpr bool bGenerateInlineAssertionsForStructMembers = false;
+        /* Prefix for assertion macros in assertion file. Example for "MyPackage_params.hpp": #define DUMPER7_ASSERTS_PARAMS_MyPackage */
+        inline constexpr const char* AssertionMacroPrefix = "DUMPER7_ASSERTS_";
 
 
-		/* Prints debug information during Mapping-Generation */
-		inline constexpr bool bShouldPrintMappingDebugData = false;
-	}
+        /* Adds static_assert for struct-size, as well as struct-alignment */
+        inline constexpr bool bGenerateInlineAssertionsForStructSize = false;
 
-	//* * * * * * * * * * * * * * * * * * * * *// 
-	// Do **NOT** change any of these settings //
-	//* * * * * * * * * * * * * * * * * * * * *//
-	namespace Internal
-	{
-		/* Whether UEnum::Names stores only the name of the enum value, or a Pair<Name, Value> */
-		inline bool bIsEnumNameOnly = false; // EDemoPlayFailure
+        /* Adds static_assert for member-offsets */
+        inline constexpr bool bGenerateInlineAssertionsForStructMembers = false;
 
-		/* Whether the 'Value' component in the Pair<Name, Value> UEnum::Names is a uint8 value, rather than the default int64 */
-		inline bool bIsSmallEnumValue = false;
 
-		/* Whether TWeakObjectPtr contains 'TagAtLastTest' */
-		inline bool bIsWeakObjectPtrWithoutTag = false;
+        /* Prints debug information during Mapping-Generation */
+        inline constexpr bool bShouldPrintMappingDebugData = false;
+    }
 
-		/* Whether this games' engine version uses FProperty rather than UProperty */
-		inline bool bUseFProperty = false;
+    //* * * * * * * * * * * * * * * * * * * * *// 
+    // Do **NOT** change any of these settings //
+    //* * * * * * * * * * * * * * * * * * * * *//
+    namespace Internal
+    {
+        /* Whether UEnum::Names stores only the name of the enum value, or a Pair<Name, Value> */
+        inline bool bIsEnumNameOnly = false; // EDemoPlayFailure
 
-		/* Whether this game's engine version uses FNamePool rather than TNameEntryArray */
-		inline bool bUseNamePool = false;
+        /* Whether the 'Value' component in the Pair<Name, Value> UEnum::Names is a uint8 value, rather than the default int64 */
+        inline bool bIsSmallEnumValue = false;
 
-		/* Whether UObject::Name or UObject::Class is first. Affects the calculation of the size of FName in fixup code. Not used after Off::Init(); */
-		inline bool bIsObjectNameBeforeClass = false;
+        /* Whether TWeakObjectPtr contains 'TagAtLastTest' */
+        inline bool bIsWeakObjectPtrWithoutTag = false;
 
-		/* Whether this games uses case-sensitive FNames, adding int32 DisplayIndex to FName */
-		inline bool bUseCasePreservingName = false;
+        /* Whether this games' engine version uses FProperty rather than UProperty */
+        inline bool bUseFProperty = false;
 
-		/* Whether this games uses FNameOutlineNumber, moving the 'Number' component from FName into FNameEntry inside of FNamePool */
-		inline bool bUseOutlineNumberName = false;
+        /* Whether this game's engine version uses FNamePool rather than TNameEntryArray */
+        inline bool bUseNamePool = false;
 
-		/* Whether this game uses the 'FFieldPathProperty' cast flags for a custom property 'FObjectPtrProperty' */
-		inline bool bIsObjPtrInsteadOfFieldPathProperty = false;
+        /* Whether UObject::Name or UObject::Class is first. Affects the calculation of the size of FName in fixup code. Not used after Off::Init(); */
+        inline bool bIsObjectNameBeforeClass = false;
 
-		/* Whether this games' engine version uses a contexpr flag to determine whether a FFieldVariant holds a UObject* or FField* */
-		inline bool bUseMaskForFieldOwner = false;
+        /* Whether this games uses case-sensitive FNames, adding int32 DisplayIndex to FName */
+        inline bool bUseCasePreservingName = false;
 
-		/* Whether this games' engine version uses double for FVector, instead of float. Aka, whether the engine version is UE5.0 or higher. */
-		inline bool bUseLargeWorldCoordinates = false;
+        /* Whether this games uses FNameOutlineNumber, moving the 'Number' component from FName into FNameEntry inside of FNamePool */
+        inline bool bUseOutlineNumberName = false;
 
-		/* Whether this game uses uint8 for UEProperty::ArrayDim, instead of int32 */
-		inline bool bUseUint8ArrayDim = false;
-	}
+        /* Whether this game uses the 'FFieldPathProperty' cast flags for a custom property 'FObjectPtrProperty' */
+        inline bool bIsObjPtrInsteadOfFieldPathProperty = false;
 
-	extern void InitWeakObjectPtrSettings();
-	extern void InitLargeWorldCoordinateSettings();
+        /* Whether this games' engine version uses a contexpr flag to determine whether a FFieldVariant holds a UObject* or FField* */
+        inline bool bUseMaskForFieldOwner = false;
 
-	extern void InitObjectPtrPropertySettings();
-	extern void InitArrayDimSizeSettings();
+        /* Whether this games' engine version uses double for FVector, instead of float. Aka, whether the engine version is UE5.0 or higher. */
+        inline bool bUseLargeWorldCoordinates = false;
+
+        /* Whether this game uses uint8 for UEProperty::ArrayDim, instead of int32 */
+        inline bool bUseUint8ArrayDim = false;
+    }
+
+    extern void InitWeakObjectPtrSettings();
+    extern void InitLargeWorldCoordinateSettings();
+
+    extern void InitObjectPtrPropertySettings();
+    extern void InitArrayDimSizeSettings();
 }

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -1,7 +1,10 @@
-#include <Windows.h>
-#include <iostream>
+#define WIN32_LEAN_AND_MEAN   
 #include <chrono>
-#include <fstream>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <windows.h>
 
 #include "Generators/CppGenerator.h"
 #include "Generators/MappingGenerator.h"
@@ -9,6 +12,27 @@
 #include "Generators/DumpspaceGenerator.h"
 
 #include "Generators/Generator.h"
+
+// kind of doesnt need to be its own function but doesnt hurt either
+std::filesystem::path get_module_path(HMODULE module)
+{
+    WCHAR buf[256];
+    return GetModuleFileNameW(module, buf, ARRAYSIZE(buf)) ? buf : std::filesystem::path();
+}
+
+// Using atomics to allow waiting for keypress in a separate thread without race conditions
+std::atomic<bool> keyPressed = false;
+
+// Reads ints from the ini file, use the actual value for VK scancodes, e.g. 0x77 = F8
+void listener(int key)
+{
+    while (!keyPressed)
+    {
+        keyPressed = GetAsyncKeyState(key) & 0x8000;
+    }
+    Sleep(50);
+}
+
 
 enum class EFortToastType : uint8
 {
@@ -18,84 +42,114 @@ enum class EFortToastType : uint8
         EFortToastType_MAX             = 3,
 };
 
-DWORD MainThread(HMODULE Module)
-{
-	AllocConsole();
-	FILE* Dummy;
-	freopen_s(&Dummy, "CONOUT$", "w", stderr);
-	freopen_s(&Dummy, "CONIN$", "r", stdin);
 
-	auto t_1 = std::chrono::high_resolution_clock::now();
+// Kind of had to make this a separate function for the control flow
+static int Dump(HMODULE Module) {
+    AllocConsole();
+    FILE* Dummy;
+    freopen_s(&Dummy, "CONOUT$", "w", stderr);
+    freopen_s(&Dummy, "CONIN$", "r", stdin);
 
-	std::cerr << "Started Generation [Dumper-7]!\n";
+    auto t_1 = std::chrono::high_resolution_clock::now();
 
-	Settings::Config::Load();
+    std::cerr << "Started Generation [Dumper-7]!\n";
+    Generator::InitEngineCore();
+    Generator::InitInternal();
 
-	if (Settings::Config::SleepTimeout > 0)
-	{
-		std::cerr << "Sleeping for " << Settings::Config::SleepTimeout << "ms...\n";
-		Sleep(Settings::Config::SleepTimeout);
-	}
+    if (Settings::Generator::GameName.empty() && Settings::Generator::GameVersion.empty())
+    {
+        // Only Possible in Main()
+        FString Name;
+        FString Version;
+        UEClass Kismet = ObjectArray::FindClassFast("KismetSystemLibrary");
+        UEFunction GetGameName = Kismet.GetFunction("KismetSystemLibrary", "GetGameName");
+        UEFunction GetEngineVersion = Kismet.GetFunction("KismetSystemLibrary", "GetEngineVersion");
 
-	Generator::InitEngineCore();
-	Generator::InitInternal();
+        Kismet.ProcessEvent(GetGameName, &Name);
+        Kismet.ProcessEvent(GetEngineVersion, &Version);
 
-	if (Settings::Generator::GameName.empty() && Settings::Generator::GameVersion.empty())
-	{
-		// Only Possible in Main()
-		FString Name;
-		FString Version;
-		UEClass Kismet = ObjectArray::FindClassFast("KismetSystemLibrary");
-		UEFunction GetGameName = Kismet.GetFunction("KismetSystemLibrary", "GetGameName");
-		UEFunction GetEngineVersion = Kismet.GetFunction("KismetSystemLibrary", "GetEngineVersion");
+        Settings::Generator::GameName = Name.ToString();
+        Settings::Generator::GameVersion = Version.ToString();
+        Settings::Internal::bUseLargeWorldCoordinates = Version.ToString().find("UE4") != std::string::npos ? false : true;
+    }
 
-		Kismet.ProcessEvent(GetGameName, &Name);
-		Kismet.ProcessEvent(GetEngineVersion, &Version);
+    std::cerr << "GameName: " << Settings::Generator::GameName << "\n";
+    std::cerr << "GameVersion: " << Settings::Generator::GameVersion << "\n\n";
+    Generator::Generate<MappingGenerator>();
+    Generator::Generate<CppGenerator>();
+    Generator::Generate<IDAMappingGenerator>();
+    Generator::Generate<DumpspaceGenerator>();
 
-		Settings::Generator::GameName = Name.ToString();
-		Settings::Generator::GameVersion = Version.ToString();
-	}
+    auto t_C = std::chrono::high_resolution_clock::now();
 
-	std::cerr << "GameName: " << Settings::Generator::GameName << "\n";
-	std::cerr << "GameVersion: " << Settings::Generator::GameVersion << "\n\n";
+    auto ms_int_ = std::chrono::duration_cast<std::chrono::milliseconds>(t_C - t_1);
+    std::chrono::duration<double, std::milli> ms_double_ = t_C - t_1;
 
-	Generator::Generate<CppGenerator>();
-	Generator::Generate<MappingGenerator>();
-	Generator::Generate<IDAMappingGenerator>();
-	Generator::Generate<DumpspaceGenerator>();
+    std::cerr << "\n\nGenerating SDK took (" << ms_double_.count() << "ms)\n\n\n";
+    
+    // wait a few seconds and then unload automatically
+    // If someone wants to prevent this they can just click on the console output to pause execution
+    // actually this change doesn't matter, but I felt like it was odd to have an exit key and not have it configurable
+    // maybe just reuse the dumpkey if its given or just revert this portion idc
+    Sleep(5000);
+    fclose(stderr);
+    if (Dummy) fclose(Dummy);
+    FreeConsole();
 
-	auto t_C = std::chrono::high_resolution_clock::now();
-
-	auto ms_int_ = std::chrono::duration_cast<std::chrono::milliseconds>(t_C - t_1);
-	std::chrono::duration<double, std::milli> ms_double_ = t_C - t_1;
-
-	std::cerr << "\n\nGenerating SDK took (" << ms_double_.count() << "ms)\n\n\n";
-
-	while (true)
-	{
-		if (GetAsyncKeyState(VK_F6) & 1)
-		{
-			fclose(stderr);
-			if (Dummy) fclose(Dummy);
-			FreeConsole();
-
-			FreeLibraryAndExitThread(Module, 0);
-		}
-
-		Sleep(100);
-	}
-
-	return 0;
+    FreeLibraryAndExitThread(Module, 0);
+    return 0;
 }
+
+
+
+DWORD MainThread(HMODULE Module) {
+    // Grab the path to the dll in case you want to store your settings file adjacent to it and have it out of the game directory
+    Settings::Config::ModulePath = get_module_path(Module).string();
+    Settings::Config::Load();
+    std::cerr << Settings::Generator::SDKGenerationPath;
+    static auto t_0 = std::chrono::high_resolution_clock::now();
+    // Dump immediately if no timeout or dump key is set
+    if (Settings::Config::SleepTimeout + Settings::Config::DumpKey == 0)
+        return Dump(Module);
+    // If a timeout is set without a dumpkey we will just synchronously wait and then dump
+    if (Settings::Config::DumpKey == 0) {
+        Sleep(Settings::Config::SleepTimeout);
+        return Dump(Module);
+    }
+    // When a dump key is set we need to suspend execution and wait asynchronously to avoid unloading or dumping early
+    else {
+        std::thread listenerThread(&listener, Settings::Config::DumpKey);
+        listenerThread.detach();
+        auto t_x = std::chrono::high_resolution_clock::now();
+        while (!keyPressed)
+        {
+        // And finally in the case that both a dump key and timeout are set we will continue checking back on this thread
+            if (Settings::Config::SleepTimeout > 0) {
+                t_x = std::chrono::high_resolution_clock::now();
+                auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(t_x - t_0).count();
+                if (diff >= Settings::Config::SleepTimeout) {
+                    std::cerr << "Timeout reached, dumping SDK...\n";
+                    return Dump(Module);
+                }
+            }
+            Sleep(100);
+        }
+        return Dump(Module);
+    }
+
+}
+
+
+
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved)
 {
-	switch (reason)
-	{
-	case DLL_PROCESS_ATTACH:
-		CreateThread(0, 0, (LPTHREAD_START_ROUTINE)MainThread, hModule, 0, 0);
-		break;
-	}
+    switch (reason)
+    {
+    case DLL_PROCESS_ATTACH:
+        CreateThread(0, 0, (LPTHREAD_START_ROUTINE)MainThread, hModule, 0, 0);
+        break;
+    }
 
-	return TRUE;
+    return TRUE;
 }


### PR DESCRIPTION
I've added the option to set a keybind to trigger dumps with handling to allow using this option alongside the sleep timeout if desired. Additionally you can now set sdk generation path and configs can be placed next to the dll if you're injecting from a shared folder. In the case of multiple configs the game local version will win out. The dll option takes our handle from dllmain rather than assuming we're named Dumper-7.dll, mainly because I also added a dsound.dll proxy in my fork (I could also push that but IMO it makes it too easy)

Everything works well and has been tested for a few weeks now and I have left comments inline for the devs and a markdown file + example ini for the masses. Feel free to make any necessary changes