### PR TITLE
Add TArray cstor that allows to create a new TArray from pointer

### DIFF
--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -5977,7 +5977,12 @@ namespace UC
 
 	public:
 		TArray()
-			: Data(nullptr), NumElements(0), MaxElements(0)
+			: TArray(nullptr, 0, 0)
+		{
+		}
+
+		TArray(ArrayElementType* Data, int32 NumElements, int32 MaxElements)
+			: Data(Data), NumElements(NumElements), MaxElements(MaxElements)
 		{
 		}
 


### PR DESCRIPTION
It's very useful to create arrays on stack just to call a function that needs an array input.  
Allows to use it like this:
```cpp
uint16 states[1];
states[0] = 123;
TArray<uint16> stateStack(states, 1, 1);
myPlayer->_stateMachine->Server_SetStateStack(stateStack);
```