### PR TITLE
Improved IterateAllSectionObjects to check if section contains readable memory

### DIFF
--- a/Dumper/Platform/Private/PlatformWindows.cpp
+++ b/Dumper/Platform/Private/PlatformWindows.cpp
@@ -173,6 +173,9 @@ namespace
 		{
 			const IMAGE_SECTION_HEADER* CurrentSection = &Sections[i];
 
+			if ((CurrentSection->Characteristics & IMAGE_SCN_MEM_READ) == 0)
+				continue;
+
 			if (Callback(CurrentSection))
 				return CurrentSection;
 		}


### PR DESCRIPTION
In *The Outlast Trials*, I ran into an issue where some sections iterated by `IterateAllSectionObjects` function were empty and had no valid access rights, causing a crash.
I’m not sure if `IterateAllSectionObjects` could or should be improved further, but adding the readability check fixed the problem and seems like a generally useful change.
