### PR TITLE
Fixed out of bounds reads caused by signed/unsigned missmatch, added …

### DIFF
--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -530,18 +530,13 @@ void PropertySizes::InitTMulticastInlineDelegateSize()
 
 	const UEClass EmitterClass = ObjectArray::FindClassFast("Emitter");
 
-	std::cerr << "EmitterClass: " << EmitterClass.GetAddress() << "\n";
-
 	if (!EmitterClass)
 		return OnPropertyNotFound();
 
 	const UEProperty OnParticleSpawn = EmitterClass.FindMember("OnParticleSpawn", EClassCastFlags::MulticastDelegateProperty);
 
-	std::cerr << "OnParticleSpawn: " << OnParticleSpawn.GetAddress() << "\n";
 	if (!OnParticleSpawn)
 		return OnPropertyNotFound();
-
-	std::cerr << std::format("OnParticleSpawn Property Size: 0x{:X}\n", OnParticleSpawn.GetSize());
 
 	PropertySizes::MulticastInlineDelegateProperty = OnParticleSpawn.GetSize();
 }

--- a/Dumper/Engine/Private/Unreal/NameArray.cpp
+++ b/Dumper/Engine/Private/Unreal/NameArray.cpp
@@ -610,7 +610,7 @@ bool NameArray::TryInit(int32 OffsetOverride, bool bIsNamePool, const char* cons
 	return false;
 }
 
-bool NameArray::SetGNamesWithoutCommiting()
+bool NameArray::SetGNamesWithoutCommitting()
 {
 	/* GNames is already set */
 	if (Off::InSDK::NameArray::GNames != 0x0)

--- a/Dumper/Engine/Private/Unreal/UnrealTypes.cpp
+++ b/Dumper/Engine/Private/Unreal/UnrealTypes.cpp
@@ -175,7 +175,7 @@ void FName::Init_Windows(bool bForceGNames)
 		else /* Attempt to find FName::ToString as a final fallback */
 		{
 			/* Initialize GNames offset without committing to use GNames during the dumping process or in the SDK */
-			NameArray::SetGNamesWithoutCommiting();
+			NameArray::SetGNamesWithoutCommitting();
 			FName::InitFallback();
 		}
 	}
@@ -183,7 +183,7 @@ void FName::Init_Windows(bool bForceGNames)
 	std::cerr << std::format("Found FName::{} at Offset 0x{:X}\n\n", (Off::InSDK::Name::bIsUsingAppendStringOverToString ? "AppendString" : "ToString"), Off::InSDK::Name::AppendNameToString);
 
 	/* Initialize GNames offset without committing to use GNames during the dumping process or in the SDK */
-	NameArray::SetGNamesWithoutCommiting();
+	NameArray::SetGNamesWithoutCommitting();
 
 	if (ToStr)
 		return;

--- a/Dumper/Engine/Public/Unreal/Enums.h
+++ b/Dumper/Engine/Public/Unreal/Enums.h
@@ -99,6 +99,11 @@ enum class EPropertyFlags : uint64
 	NativeAccessSpecifierProtected	= 0x0020000000000000,
 	NativeAccessSpecifierPrivate	= 0x0040000000000000,	
 	SkipSerialization				= 0x0080000000000000, 
+	TObjectPtr						= 0x0100000000000000,
+	ExperimentalOverridableLogic	= 0x0200000000000000,
+	ExperimentalAlwaysOverriden		= 0x0400000000000000,
+	ExperimentalNeverOverriden		= 0x0800000000000000,
+	AllowSelfReference				= 0x1000000000000000,
 };
 
 enum class EFunctionFlags : uint32
@@ -473,6 +478,11 @@ static std::string StringifyPropertyFlags(EPropertyFlags PropertyFlags)
 	if (PropertyFlags & EPropertyFlags::NativeAccessSpecifierPublic) { RetFlags += "NativeAccessSpecifierPublic, "; }
 	if (PropertyFlags & EPropertyFlags::NativeAccessSpecifierProtected) { RetFlags += "NativeAccessSpecifierProtected, "; }
 	if (PropertyFlags & EPropertyFlags::NativeAccessSpecifierPrivate) { RetFlags += "NativeAccessSpecifierPrivate, "; }
+	if (PropertyFlags & EPropertyFlags::TObjectPtr) { RetFlags += "TObjectPtr, "; }
+	if (PropertyFlags & EPropertyFlags::ExperimentalOverridableLogic) { RetFlags += "ExperimentalOverridableLogic, "; }
+	if (PropertyFlags & EPropertyFlags::ExperimentalAlwaysOverriden) { RetFlags += "ExperimentalAlwaysOverriden, "; }
+	if (PropertyFlags & EPropertyFlags::ExperimentalNeverOverriden) { RetFlags += "ExperimentalNeverOverriden, "; }
+	if (PropertyFlags & EPropertyFlags::AllowSelfReference) { RetFlags += "AllowSelfReference, "; }
 
 	return RetFlags.size() > 2 ? RetFlags.erase(RetFlags.size() - 2) : RetFlags;
 }

--- a/Dumper/Engine/Public/Unreal/NameArray.h
+++ b/Dumper/Engine/Public/Unreal/NameArray.h
@@ -58,7 +58,7 @@ public:
 	static bool TryInit(int32 OffsetOverride, bool bIsNamePool, const char* const ModuleName = Settings::General::DefaultModuleName);
 
 	/* Initializes the GNames offset, but doesn't call NameArray::InitializeNameArray() or NameArray::InitializedNamePool() */
-	static bool SetGNamesWithoutCommiting();
+	static bool SetGNamesWithoutCommitting();
 
 	static void PostInit();
 	

--- a/Dumper/Generator/Private/Managers/MemberManager.cpp
+++ b/Dumper/Generator/Private/Managers/MemberManager.cpp
@@ -160,6 +160,7 @@ void MemberManager::InitReservedNames()
 	MemberNames.AddReservedName("private");
 	MemberNames.AddReservedName("public");
 	MemberNames.AddReservedName("const");
+	MemberNames.AddReservedName("requires");
 
 	/* Unreal Engine typedefs */
 	MemberNames.AddReservedName("int8");

--- a/Dumper/Platform/Private/PlatformWindows.cpp
+++ b/Dumper/Platform/Private/PlatformWindows.cpp
@@ -197,9 +197,15 @@ namespace
 		return { NULL, 0 };
 	}
 
-	inline uint32_t GetAlignedSizeWithOffsetFromEnd(const uint32_t SizeToAlign, const uint32_t Alignment, const uint32_t OffsetFromEnd)
+	inline int64_t GetAlignedSizeWithOffsetFromEnd(const uint32_t SizeToAlign, const uint32_t Alignment, const uint32_t OffsetFromEnd)
 	{
-		return Align((SizeToAlign - (Alignment - 1) - OffsetFromEnd), Alignment);
+		const uint32_t ValueToAlign = (SizeToAlign - (Alignment - 1) - OffsetFromEnd);
+
+		// There was an underflow in the above subtraction
+		if (ValueToAlign > SizeToAlign)
+			return -1;
+
+		return Align(ValueToAlign, Alignment);
 	}
 
 	inline const PIMAGE_THUNK_DATA GetImportAddress(const uintptr_t ModuleBase, const char* ModuleToImportFrom, const char* SearchFunctionName)
@@ -327,10 +333,9 @@ namespace
 
 void* WindowsPrivateImplHelper::FinAlignedValueInRangeImpl(const void* ValuePtr, ValueCompareFuncType ComparisonFunction, const int32_t ValueTypeSize, const int32_t Alignment, uintptr_t StartAddress, uint32_t Range)
 {
-	for (uint32_t i = 0x0; i <= GetAlignedSizeWithOffsetFromEnd(Range, Alignment, ValueTypeSize); i += Alignment)
+	for (int64_t i = 0x0; i <= GetAlignedSizeWithOffsetFromEnd(Range, Alignment, ValueTypeSize); i += Alignment)
 	{
 		void* TypedPtr = reinterpret_cast<void*>(StartAddress + i);
-
 
 		if (ComparisonFunction(ValuePtr, TypedPtr))
 			return TypedPtr;
@@ -686,10 +691,10 @@ void* PlatformWindows::FindPatternInRange(const char* Signature, const uintptr_t
 
 void* PlatformWindows::FindPatternInRange(std::vector<int>&& Signature, const void* Start, const uintptr_t Range, const bool bRelative, uint32_t Offset, const uint32_t SkipCount)
 {
-	const auto PatternLength = Signature.size();
+	const auto PatternLength = static_cast<int64_t>(Signature.size());
 	const auto PatternBytes = Signature.data();
 
-	for (int i = 0; i < (Range - PatternLength); i++)
+	for (int i = 0; i < (static_cast<int64_t>(Range) - PatternLength); i++)
 	{
 		bool bFound = true;
 		int CurrentSkips = 0;
@@ -768,7 +773,7 @@ inline void* PlatformWindows::FindStringInRange(const CharType* RefStr, const ui
 	// Ensure the null-terminator is also compared, else strings that are substrings of other strings might be falsely matched.
 	const int32_t RefStrLen = StrlenHelper(RefStr) + 1;
 
-	for (uintptr_t i = 0; i < Range; i++)
+	for (int32 i = 0; i < Range; i++)
 	{
 #if defined(_WIN64)
 		// opcode: lea


### PR DESCRIPTION
…'requires' as reserved keyword, fixed spelling of SetGNamesWithoutCommitting.