### PR TITLE
Optional dump key and output path features

### DIFF
--- a/Dumper/Settings.cpp
+++ b/Dumper/Settings.cpp
@@ -203,3 +203,38 @@ void Settings::Config::Load()
 		}
 	}
 }
+
+void Settings::Config::DelayDumperStart()
+{	
+	if (DumpKey == 0)
+	{
+		// Sleeping for the default of 0 ms has no effect here 
+		Sleep(SleepTimeout);
+		return;
+	}
+
+	const auto DelayStartTime = std::chrono::high_resolution_clock::now();
+
+	while (true)
+	{
+		if (GetAsyncKeyState(DumpKey) & 0x8000)
+		{
+			return;
+		}
+
+		if (SleepTimeout > 0) 
+		{
+			const auto Now = std::chrono::high_resolution_clock::now(); 
+			const auto ElapsedTime = std::chrono::duration<double, std::milli>(Now - DelayStartTime); 
+			if (ElapsedTime.count() > SleepTimeout) 
+			{
+				std::cerr << "Sleep Timeout exceeded, proceeding with dump...\n"; 
+				return;
+			}
+		}
+			
+		Sleep(50);
+	}
+}
+
+

--- a/Dumper/Settings.cpp
+++ b/Dumper/Settings.cpp
@@ -126,10 +126,36 @@ void Settings::Config::Load()
 	// If no config found, use defaults
 	if (!ConfigPath) 
 		return;
-
 	char SDKNamespace[256] = {};
 	GetPrivateProfileStringA("Settings", "SDKNamespaceName", "SDK", SDKNamespace, sizeof(SDKNamespace), ConfigPath);
-
 	SDKNamespaceName = SDKNamespace;
+
+	if (strcmp(SDKNamespace, "SDK") != 0)
+		std::cerr << "Using custom namespace: " << SDKNamespaceName << std::endl;
+
+	// Check for output path override. This will be relative to the game folder unless a drive is specified
+	char SDKPath[256] = {};
+	GetPrivateProfileStringA("Settings", "SDKGenerationPath", "C:/Dumper-7", SDKPath, sizeof(SDKPath), ConfigPath);
+
+	Settings::Generator::SDKGenerationPath = SDKPath;
+	std::cerr << "Dumper-7 SDK Generation Path: " << SDKPath << std::endl;
+
+	// VK scancode ID as an Int, e.g. 0x77 or 119 = VK_F8 (yes actually type 0x77 in your ini)
+	DumpKey = GetPrivateProfileIntA("Settings", "DumpKey", 0, ConfigPath);
+	if (DumpKey != 0)
+	{
+		// Use winapi to retrieve the real key name without needing to hardcode a mapping 
+		//	not necesssary but its nice QOL to know your key is set properly
+		char keyName[256] = {};
+		LONG lParamValue = (MapVirtualKeyA(DumpKey, MAPVK_VK_TO_VSC) << 16);
+		if (GetKeyNameTextA(lParamValue, keyName, sizeof(keyName)) != 0)
+			std::cerr << "Press " << keyName << " to begin dump." << std::endl;
+	}
+
+	// Set a sleep timeout after which point generation will begin automatically even if a key is set. 0 = disabled
 	SleepTimeout = max(GetPrivateProfileIntA("Settings", "SleepTimeout", 0, ConfigPath), 0);
+	// Convert seconds to ms automatically if a value under 1 second is set
+	if (SleepTimeout < 1000)
+		SleepTimeout *= 1000;
+	std::cerr << "Sleep Timeout: " << std::dec << SleepTimeout << "ms" << std::endl;
 }

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -19,6 +19,7 @@ namespace Settings
 
 	namespace Config
 	{
+		inline int DumpKey = 0;
 		inline int SleepTimeout = 0;
 		inline std::string SDKNamespaceName = "SDK";
 

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -110,7 +110,7 @@ R"(
 		inline constexpr bool bGenerateInlineAssertionsForStructSize = false;
 
 		/* Adds static_assert for member-offsets */
-		inline constexpr bool bGenerateInlineAssertionsForStructMembers = true;
+		inline constexpr bool bGenerateInlineAssertionsForStructMembers = false;
 
 
 		/* Prints debug information during Mapping-Generation */

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -20,6 +20,7 @@ namespace Settings
 	namespace Config
 	{
 		inline int SleepTimeout = 0;
+		inline int DumpKey = 0;
 		inline std::string SDKNamespaceName = "SDK";
 
 		void Load();
@@ -108,7 +109,7 @@ R"(
 		inline constexpr bool bGenerateInlineAssertionsForStructSize = false;
 
 		/* Adds static_assert for member-offsets */
-		inline constexpr bool bGenerateInlineAssertionsForStructMembers = false;
+		inline constexpr bool bGenerateInlineAssertionsForStructMembers = true;
 
 
 		/* Prints debug information during Mapping-Generation */

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -24,6 +24,7 @@ namespace Settings
 		inline std::string SDKNamespaceName = "SDK";
 
 		void Load();
+		void DelayDumperStart();
 	};
 
 	namespace EngineCore

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -40,7 +40,7 @@ namespace Settings
 		inline std::string GameName = "";
 		inline std::string GameVersion = "";
 
-		inline constexpr const char* SDKGenerationPath = "C:/Dumper-7";
+		inline std::string SDKGenerationPath = "C:/Dumper-7";
 	}
 
 	namespace CppGenerator

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -19,7 +19,6 @@ namespace Settings
 
 	namespace Config
 	{
-		inline int DumpKey = 0;
 		inline int SleepTimeout = 0;
 		inline int DumpKey = 0;
 		inline std::string SDKNamespaceName = "SDK";

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -12,14 +12,11 @@
 
 enum class EFortToastType : uint8
 {
-		Default                        = 0,
-		Subdued                        = 1,
-		Impactful                      = 2,
-		EFortToastType_MAX             = 3,
+        Default                        = 0,
+        Subdued                        = 1,
+        Impactful                      = 2,
+        EFortToastType_MAX             = 3,
 };
-
-// signal for our keylistener. must be declared at file scope to be readable in the lambda
-std::atomic<bool> dumpStarted = false;
 
 DWORD MainThread(HMODULE Module)
 {
@@ -46,7 +43,7 @@ DWORD MainThread(HMODULE Module)
 			if (Settings::Config::SleepTimeout > 0) 
 			{
 				const auto Now = std::chrono::high_resolution_clock::now();
-				const auto ElapsedTime = std::chrono::duration<double, std::milli>(Now -DelayStartTime);
+				const auto ElapsedTime = std::chrono::duration<double, std::milli>(Now - DelayStartTime);
 				if (ElapsedTime.count() > Settings::Config::SleepTimeout) 
 				{
 					std::cerr << "Sleep Timeout exceeded, proceeding with dump...\n";
@@ -94,7 +91,7 @@ DWORD MainThread(HMODULE Module)
 	Generator::Generate<MappingGenerator>();
 	Generator::Generate<IDAMappingGenerator>();
 	Generator::Generate<DumpspaceGenerator>();
-	
+
 	auto DumpFinishTime = std::chrono::high_resolution_clock::now();
 
 	std::chrono::duration<double, std::milli> DumpTime = DumpFinishTime - DumpStartTime;
@@ -102,6 +99,7 @@ DWORD MainThread(HMODULE Module)
 	std::cerr << "\n\nGenerating SDK took (" << DumpTime.count() << "ms)\n\n\n";
 
 	std::cerr << "\n\nPress F6 to unload\n\n\n";
+
 	while (true)
 	{
 		if (GetAsyncKeyState(VK_F6) & 1)

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -20,6 +20,8 @@ enum class EFortToastType : uint8
         EFortToastType_MAX             = 3,
 };
 
+std::atomic<bool> dumpStarted = false;
+
 DWORD MainThread(HMODULE Module)
 {
 	AllocConsole();

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <chrono>
 #include <fstream>
+#include <thread>
+#include <atomic>
 
 #include "Generators/CppGenerator.h"
 #include "Generators/MappingGenerator.h"
@@ -25,17 +27,60 @@ DWORD MainThread(HMODULE Module)
 	freopen_s(&Dummy, "CONOUT$", "w", stderr);
 	freopen_s(&Dummy, "CONIN$", "r", stdin);
 
-	std::cerr << "Started Generation [Dumper-7]!\n";
+/*
+	this block makes it so the game and main dump thread 
+	doesn't pause when clicking and highlighting text in the console
+	if this is considered a useful/desirable behavior remove this
+*/
+	auto hStdin = GetStdHandle(STD_INPUT_HANDLE);
+	DWORD mode;
+	GetConsoleMode(hStdin, &mode);
+	mode &= ~ENABLE_QUICK_EDIT_MODE;   
+	SetConsoleMode(hStdin, mode);
 
-	Settings::Config::Load();
-
-	if (Settings::Config::SleepTimeout > 0)
+	// using shorthands to avoid wrapping some longer lines
+	using namespace std::chrono;
+	namespace cfg = Settings::Config;
+	auto t_1 = high_resolution_clock::now();
+	
+	cfg::Load();
+	
+	if (cfg::DumpKey != 0)
 	{
-		std::cerr << "Sleeping for " << Settings::Config::SleepTimeout << "ms...\n";
-		Sleep(Settings::Config::SleepTimeout);
+		// we must use a detached thread to wait for the keypress otherwise we just run or unload if the first check fails
+		// using a lambda improves readability but requires more care to avoid an std::terminate being called
+		// the thread has to be detached or joined before it goes out of scope and it can't have any dangling resources
+		// therefore we avoid capturing anything by reference and pass direct values for the minimal necessary data 
+		std::thread listenerThread([Key = cfg::DumpKey, st = t_1, SleepTimeout = cfg::SleepTimeout]() 
+		{
+			while (true)
+			{
+				// 0x8000 means that the key has to be currently held so we need relatively frequent updates
+				if (GetAsyncKeyState(Key) & 0x8000) break;
+				// If sleep timeout is 0 we don't have to evaluate past the first expression
+				// If std::chrono isn't abbreviated we have to wrap this line or evaluate the time diff in a temp variable
+				if (0 < SleepTimeout && duration_cast<milliseconds>(high_resolution_clock::now() - st).count() > SleepTimeout)
+				{
+					std::cerr << "Sleep Timeout exceeded, proceeding with dump...\n";
+					break;
+				}
+				Sleep(50); // 50ms should be a good balance to get keypresses without any cpu strain
+			}
+			dumpStarted = true; // tell the main thread loop to proceed. This thread will cleanup on its own
+		});
+		listenerThread.detach();
+		// we have to do something to keep our main thread going and block the dump from starting
+		while (!dumpStarted) Sleep(50);	
+	}
+	else // no dump key set, default behavior, sleep timeout is printed during config load now
+	{
+		Sleep(cfg::SleepTimeout); // Sleep(0) is fine here it will just yield the thread
 	}
 
-	auto DumpStartTime = std::chrono::high_resolution_clock::now();
+	// move the started generation message after any timeout
+	std::cerr << "Started Generation [Dumper-7]!\n";
+	// reuse the timepoint var we set for the dumpkey
+	t_1 = high_resolution_clock::now();
 
 	Generator::InitEngineCore();
 	Generator::InitInternal();
@@ -65,13 +110,10 @@ DWORD MainThread(HMODULE Module)
 	Generator::Generate<MappingGenerator>();
 	Generator::Generate<IDAMappingGenerator>();
 	Generator::Generate<DumpspaceGenerator>();
-
-	auto DumpFinishTime = std::chrono::high_resolution_clock::now();
-
-	std::chrono::duration<double, std::milli> DumpTime = DumpFinishTime - DumpStartTime;
-
-	std::cerr << "\n\nGenerating SDK took (" << DumpTime.count() << "ms)\n\n\n";
-
+	
+	// calculate time inline. only possible to fit without wrapping with std::chrono abbreviated, either way better to calc inline
+	std::cerr << "\n\nGenerating SDK took (" << duration_cast<milliseconds>(high_resolution_clock::now() - t_1).count() << "ms)\n\n\n";
+	std::cerr << "\n\nPress F6 to unload";
 	while (true)
 	{
 		if (GetAsyncKeyState(VK_F6) & 1)

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -28,38 +28,8 @@ DWORD MainThread(HMODULE Module)
 	std::cerr << "Initializing [Dumper-7]\n";
 
 	Settings::Config::Load();
-
-	if (Settings::Config::DumpKey != 0)
-	{
-		auto DelayStartTime = std::chrono::high_resolution_clock::now();
-
-		while (true)
-		{
-			if (GetAsyncKeyState(Settings::Config::DumpKey) & 0x8000) 
-			{
-				break;
-			}
-
-			if (Settings::Config::SleepTimeout > 0) 
-			{
-				const auto Now = std::chrono::high_resolution_clock::now();
-				const auto ElapsedTime = std::chrono::duration<double, std::milli>(Now - DelayStartTime);
-				if (ElapsedTime.count() > Settings::Config::SleepTimeout) 
-				{
-					std::cerr << "Sleep Timeout exceeded, proceeding with dump...\n";
-					break;
-				}
-			}
-
-			Sleep(50);
-		}
-	}
-	else
-	{
-		// Sleeping for the default of 0 ms has no effect here 
-		Sleep(Settings::Config::SleepTimeout);
-	}
-
+	Settings::Config::DelayDumperStart();
+	
 	std::cerr << "Started Generation [Dumper-7]!\n";
 	auto DumpStartTime = std::chrono::high_resolution_clock::now();
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,35 @@ BTC (Bitcoin): `1DVDUMcotWzEG1tyd1FffyrYeu4YEh7spx`
 ## Config File
 You can optionally dynamically change settings through a `Dumper-7.ini` file, instead of modifying `Settings.h`.
 - **Per-game**: Create `Dumper-7.ini` in the same directory as the game's exe file.
-- **Global**: Create `Dumper-7.ini` under `C:\Dumper-7`
+- **Global**: Create `Dumper-7.ini` under `C:\Dumper-7`.
+- Profiles do not merge. In other words your global profile does not change the default settings.
+  
+- **SleepTimeout:**
+  - If non-zero dump will start after a delay
+  - Values under 1000 assumed to be in seconds, otherwise in milliseconds
+  - If both SleepTimeout and DumpKey are set whichever occurs first will trigger the dump
+- **DumpKey:** 
+  - If non-zero dump will start upon key press
+  - Value should be a hex or decimal integer corresponding to a [virtual keycode](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes).
+  - Hex integers should start with 0x.
+- **SDKNamespaceName:**
+  - Changes the namespace in the generated files.
+- **SDKGenerationPath:**
+  - Generate output at the specified path instead of `C:/Dumper-7`.
+  - Paths are relative to game executable unless you use an absolute path including drive letter.
+  - Use `..` to access parent directories. Do not include quotes.
 
-Example:
+
+### Example:
 ```ini
 [Settings]
-SleepTimeout=100
+SleepTimeout=30
 SDKNamespaceName=MyOwnSDKNamespace
+DumpKey=0x77
+SDKGenerationPath=./
 ```
+- These settings would generate the SDK in the same folder as the game and would start after 30 seconds or upon pressing F8.
+
 ## Issues
 
 If you have any issues using the Dumper, please create an Issue on this repository\


### PR DESCRIPTION
**Dump Key feature**

- off by default, can be set in the profile taking either a decimal or hex int value corresponding to VK scancode
- when enabled the startup process uses a detached thread to listen for keypresses, this has been streamlined from previous pr by using a lambda
- actual value of the key is printed to the console during config load which is helpful if the user has a local overriding profile and is generally just nice QOL
- requires std::thread and std::atomic to compile

**Sleep timeout feature**

- logic has been simplified and actually uses fewer conditionals either way
- when no dump key is set we just Sleep without bothering to check as the default value of 0 will yield the thread which effectively does nothing
- if we have a key setup then inside the same loop we do a shortcircuited eval that checks the elapsed time only if a sleep timeout 
- timeout is expected in ms as usual but when its less than 1000 we can assume the user probably wants it in seconds so we automatically convert that
- timeout settings are printed during config load just to clean up the main thread a little bit

**SDK path**

-  very minimal implementation, no environment variables or anything related to the dll file location in this patch
- If an absolute path is given it will work as expected, otherwise its relative to the game working dir and can use .. to access parent paths
 
The one change I see as possibly controversial is calling `using namespace std::chrono` in main thread. I did this to avoid having to wrap the short-circuited conditional that checks for the timeout and I also adjusted the final time calculation to use the same code and handle it inline with the print statement. If you prefer not to import the namespace or would rather use a shorthand as we already did for fs = filesystem in settings I can rewrite that. But its just an aesthetic change so if you don't mind it then I think we're good

I also did include a block of code that makes it so clicking and highlighting text on the console won't block the thread but I left it commented out in case thats an intended feature. I thought it made sense to leave it there for anyone compiling themselves since its not super well known and I personally find it annoying when I accidentally freeze a game. 

I did not bother with the example config and separate doc I had done earlier but I did add some basic explanation of features in the readme and anyone who builds it themselves should find adequate explanation in the comments as to why things are done the way they are. 

The detached thread inside the lambda is very well tested and isn't particularly fragile imo but if someone who has no clue what they're doing goes and tries to mess with that section they will probably have a bad time. e.g. if they want to capture another variable declared in the main thread, ignore the comment, and pass it by reference instead of by value it will 100% crash every time. So if you end up getting issues made about std::terminate or dangling reference crashes I would probably just tell them not to touch what they don't understand. I don't mind being tagged in an issue though and I'll add that if you wanted to ever update to C++ 20+ we can make it more thread safe with jthreads but I wasn't gonna push for that and I think this is totally fine as is.