### PR TITLE
Fixed CMake build with cpp 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ file(GLOB_RECURSE CPP_SOURCES
 
 add_library(${PROJECT_NAME} SHARED ${CPP_SOURCES})
 
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+
 # Include directories
 target_include_directories(${PROJECT_NAME} PRIVATE
 # Dumper
@@ -52,6 +54,13 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/Dumper/Generator/Public/Generators
     ${CMAKE_SOURCE_DIR}/Dumper/Generator/Public/Managers
     ${CMAKE_SOURCE_DIR}/Dumper/Generator/Public/Wrappers
+
+    # Platform
+    ${CMAKE_SOURCE_DIR}/Dumper/Platform
+    ${CMAKE_SOURCE_DIR}/Dumper/Platform/Private
+
+    # Platform Public
+    ${CMAKE_SOURCE_DIR}/Dumper/Platform/Public
 
     # Utils
     ${CMAKE_SOURCE_DIR}/Dumper/Utils

--- a/Dumper/Platform/Private/PlatformWindows.h
+++ b/Dumper/Platform/Private/PlatformWindows.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <algorithm>
 #include <functional>
+#include <bit>
 
 #include "Settings.h"
 


### PR DESCRIPTION
Module PlatformWindows uses bit_cast without <bit> in cpp20