### PR TITLE
Add UE5+ support, JSON SDK output, EFieldClassID fallback

### DIFF
--- a/Dumper/Dumper.vcxproj
+++ b/Dumper/Dumper.vcxproj
@@ -156,6 +156,7 @@
   <ItemGroup>
     <ClCompile Include="Engine\Private\OffsetFinder\OffsetFinder.cpp" />
     <ClCompile Include="Generator\Private\Generators\DumpspaceGenerator.cpp" />
+    <ClCompile Include="Generator\Private\Generators\JsonSdkGenerator.cpp" />
     <ClCompile Include="Engine\Private\Unreal\NameArray.cpp" />
     <ClCompile Include="Engine\Private\Unreal\ObjectArray.cpp" />
     <ClCompile Include="Engine\Private\OffsetFinder\Offsets.cpp" />
@@ -184,6 +185,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Generator\Public\Generators\DumpspaceGenerator.h" />
+    <ClInclude Include="Generator\Public\Generators\JsonSdkGenerator.h" />
     <ClInclude Include="Platform\Private\Arch_x86.h" />
     <ClInclude Include="Platform\Private\PlatformWindows.h" />
     <ClInclude Include="Platform\Public\Architecture.h" />

--- a/Dumper/Dumper.vcxproj.filters
+++ b/Dumper/Dumper.vcxproj.filters
@@ -53,6 +53,9 @@
     <ClCompile Include="Generator\Private\Generators\DumpspaceGenerator.cpp">
       <Filter>Generator\Private\Generators</Filter>
     </ClCompile>
+    <ClCompile Include="Generator\Private\Generators\JsonSdkGenerator.cpp">
+      <Filter>Generator\Private\Generators</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Private\OffsetFinder\Offsets.cpp">
       <Filter>Engine\Private\OffsetFinder</Filter>
     </ClCompile>
@@ -214,6 +217,9 @@
       <Filter>Utils\Json</Filter>
     </ClInclude>
     <ClInclude Include="Generator\Public\Generators\DumpspaceGenerator.h">
+      <Filter>Generator\Public\Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="Generator\Public\Generators\JsonSdkGenerator.h">
       <Filter>Generator\Public\Generators</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Encoding\UnicodeNames.h">

--- a/Dumper/Generator/Private/Generators/DumpspaceGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/DumpspaceGenerator.cpp
@@ -310,9 +310,32 @@ std::string DumpspaceGenerator::GetMemberTypeStr(UEProperty Property, std::strin
 
 		return "TOptional";
 	}
+	else if (Flags & EClassCastFlags::Utf8StrProperty)
+	{
+		return "FUtf8String";
+	}
+	else if (Flags & EClassCastFlags::AnsiStrProperty)
+	{
+		return "FAnsiString";
+	}
+	else if (Flags & EClassCastFlags::LargeWorldCoordinatesRealProperty)
+	{
+		return "double";
+	}
+	else if (Flags & EClassCastFlags::VValueProperty)
+	{
+		return "void*";
+	}
+	else if (Flags & EClassCastFlags::VRestValueProperty)
+	{
+		return "void*";
+	}
+	else if (Flags & EClassCastFlags::VCellProperty)
+	{
+		return "void*";
+	}
 	else
 	{
-		/* When changing this also change 'GetUnknownProperties()' */
 		return (Class ? Class.GetCppName() : FieldClass.GetCppName()) + "_";
 	}
 }

--- a/Dumper/Generator/Private/Generators/JsonSdkGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/JsonSdkGenerator.cpp
@@ -1,0 +1,141 @@
+#include "JsonSdkGenerator.h"
+#include "DumpspaceGenerator.h"
+
+#include "Unreal/ObjectArray.h"
+#include "Managers/DependencyManager.h"
+
+#include "../Settings.h"
+#include "Utils/Json/json.hpp"
+
+#include <fstream>
+
+nlohmann::json JsonSdkGenerator::MemberTypeToJson(const DSGen::MemberType& Type)
+{
+	nlohmann::json j;
+	j["type"] = Type.typeName;
+	j["extended"] = Type.extendedType;
+	j["ref"] = Type.reference;
+	if (!Type.subTypes.empty())
+	{
+		nlohmann::json arr = nlohmann::json::array();
+		for (const auto& st : Type.subTypes)
+			arr.push_back(MemberTypeToJson(st));
+		j["subtypes"] = arr;
+	}
+	return j;
+}
+
+nlohmann::json JsonSdkGenerator::MemberToJson(const DSGen::MemberDefinition& Member)
+{
+	nlohmann::json j;
+	j["name"] = Member.memberName;
+	j["type"] = MemberTypeToJson(Member.memberType);
+	j["offset"] = Member.offset;
+	j["size"] = Member.size;
+	j["arrayDim"] = Member.arrayDim;
+	if (Member.bitOffset >= 0)
+		j["bitOffset"] = Member.bitOffset;
+	return j;
+}
+
+nlohmann::json JsonSdkGenerator::FunctionToJson(const DSGen::FunctionHolder& Func)
+{
+	nlohmann::json j;
+	j["name"] = Func.functionName;
+	j["flags"] = Func.functionFlags;
+	j["offset"] = Func.functionOffset;
+	j["returnType"] = MemberTypeToJson(Func.returnType);
+	nlohmann::json params = nlohmann::json::array();
+	for (const auto& p : Func.functionParams)
+	{
+		nlohmann::json pj;
+		pj["type"] = MemberTypeToJson(p.first);
+		pj["name"] = p.second;
+		params.push_back(pj);
+	}
+	j["params"] = params;
+	return j;
+}
+
+nlohmann::json JsonSdkGenerator::StructOrClassToJson(const DSGen::ClassHolder& Holder, bool bIsClass)
+{
+	nlohmann::json j;
+	j["name"] = Holder.className;
+	j["size"] = Holder.classSize;
+	j["inherits"] = Holder.interitedTypes;
+	nlohmann::json members = nlohmann::json::array();
+	for (const auto& m : Holder.members)
+		members.push_back(MemberToJson(m));
+	j["members"] = members;
+	if (bIsClass && !Holder.functions.empty())
+	{
+		nlohmann::json funcs = nlohmann::json::array();
+		for (const auto& f : Holder.functions)
+			funcs.push_back(FunctionToJson(f));
+		j["functions"] = funcs;
+	}
+	return j;
+}
+
+nlohmann::json JsonSdkGenerator::EnumToJson(const DSGen::EnumHolder& Holder)
+{
+	nlohmann::json j;
+	j["name"] = Holder.enumName;
+	j["underlying"] = Holder.enumType;
+	nlohmann::json vals = nlohmann::json::array();
+	for (const auto& v : Holder.enumMembers)
+		vals.push_back({ v.first, v.second });
+	j["values"] = vals;
+	return j;
+}
+
+void JsonSdkGenerator::Generate()
+{
+	nlohmann::json sdk;
+	sdk["game"] = Settings::Generator::GameName;
+	sdk["version"] = Settings::Generator::GameVersion;
+
+	nlohmann::json structsArr = nlohmann::json::array();
+	nlohmann::json enumsArr = nlohmann::json::array();
+	nlohmann::json classesArr = nlohmann::json::array();
+
+	for (PackageInfoHandle Package : PackageManager::IterateOverPackageInfos())
+	{
+		if (Package.IsEmpty())
+			continue;
+
+		for (int32 EnumIdx : Package.GetEnums())
+		{
+			DSGen::EnumHolder Enum = DumpspaceGenerator::GenerateEnum(ObjectArray::GetByIndex<UEEnum>(EnumIdx));
+			enumsArr.push_back(EnumToJson(Enum));
+		}
+
+		DependencyManager::OnVisitCallbackType GenerateCallback = [&](int32 Index) -> void
+		{
+			DSGen::ClassHolder StructOrClass = DumpspaceGenerator::GenerateStruct(ObjectArray::GetByIndex<UEStruct>(Index));
+			if (StructOrClass.classType == DSGen::ET_Class)
+				classesArr.push_back(StructOrClassToJson(StructOrClass, true));
+			else
+				structsArr.push_back(StructOrClassToJson(StructOrClass, false));
+		};
+
+		if (Package.HasStructs())
+		{
+			const DependencyManager& Structs = Package.GetSortedStructs();
+			Structs.VisitAllNodesWithCallback(GenerateCallback);
+		}
+
+		if (Package.HasClasses())
+		{
+			const DependencyManager& Classes = Package.GetSortedClasses();
+			Classes.VisitAllNodesWithCallback(GenerateCallback);
+		}
+	}
+
+	sdk["structs"] = structsArr;
+	sdk["enums"] = enumsArr;
+	sdk["classes"] = classesArr;
+
+	std::ofstream file(MainFolder / "SDK.json");
+	file << sdk.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
+}

--- a/Dumper/Generator/Private/Generators/MappingGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/MappingGenerator.cpp
@@ -147,7 +147,62 @@ EMappingsTypeFlags MappingGenerator::GetMappingType(UEProperty Property)
 	{
 		return EMappingsTypeFlags::SoftClassProperty;
 	}
-	
+	else if (Flags & EClassCastFlags::MulticastSparseDelegateProperty)
+	{
+		return EMappingsTypeFlags::MulticastSparseDelegateProperty;
+	}
+	else if (Flags & EClassCastFlags::LargeWorldCoordinatesRealProperty)
+	{
+		return EMappingsTypeFlags::LargeWorldCoordinatesRealProperty;
+	}
+	else if (Flags & EClassCastFlags::VValueProperty)
+	{
+		return EMappingsTypeFlags::VValueProperty;
+	}
+	else if (Flags & EClassCastFlags::VRestValueProperty)
+	{
+		return EMappingsTypeFlags::VRestValueProperty;
+	}
+	else if (Flags & EClassCastFlags::VCellProperty)
+	{
+		return EMappingsTypeFlags::VCellProperty;
+	}
+
+	if (!Class && FieldClass)
+	{
+		EFieldClassID Id = FieldClass.GetId();
+		if (Id & EFieldClassID::Byte) return EMappingsTypeFlags::ByteProperty;
+		if (Id & EFieldClassID::Int8) return EMappingsTypeFlags::Int8Property;
+		if (Id & EFieldClassID::Int) return EMappingsTypeFlags::IntProperty;
+		if (Id & EFieldClassID::Int16) return EMappingsTypeFlags::Int16Property;
+		if (Id & EFieldClassID::Int64) return EMappingsTypeFlags::Int64Property;
+		if (Id & EFieldClassID::UInt16) return EMappingsTypeFlags::UInt16Property;
+		if (Id & EFieldClassID::UInt32) return EMappingsTypeFlags::UInt32Property;
+		if (Id & EFieldClassID::UInt64) return EMappingsTypeFlags::UInt64Property;
+		if (Id & EFieldClassID::Float) return EMappingsTypeFlags::FloatProperty;
+		if (Id & EFieldClassID::Double) return EMappingsTypeFlags::DoubleProperty;
+		if (Id & EFieldClassID::Bool) return EMappingsTypeFlags::BoolProperty;
+		if (Id & EFieldClassID::Name) return EMappingsTypeFlags::NameProperty;
+		if (Id & EFieldClassID::String) return EMappingsTypeFlags::StrProperty;
+		if (Id & EFieldClassID::Text) return EMappingsTypeFlags::TextProperty;
+		if (Id & EFieldClassID::Struct) return EMappingsTypeFlags::StructProperty;
+		if (Id & EFieldClassID::Array) return EMappingsTypeFlags::ArrayProperty;
+		if (Id & EFieldClassID::Map) return EMappingsTypeFlags::MapProperty;
+		if (Id & EFieldClassID::Set) return EMappingsTypeFlags::SetProperty;
+		if (Id & EFieldClassID::Enum) return EMappingsTypeFlags::EnumProperty;
+		if (Id & EFieldClassID::Object) return EMappingsTypeFlags::ObjectProperty;
+		if (Id & EFieldClassID::ObjectPointer) return EMappingsTypeFlags::ObjectProperty;
+		if (Id & EFieldClassID::Class) return EMappingsTypeFlags::ClassProperty;
+		if (Id & EFieldClassID::Interface) return EMappingsTypeFlags::InterfaceProperty;
+		if (Id & EFieldClassID::Delegate) return EMappingsTypeFlags::DelegateProperty;
+		if (Id & EFieldClassID::MulticastInlineDelegate) return EMappingsTypeFlags::MulticastInlineDelegateProperty;
+		if (Id & EFieldClassID::MulticastSparseDelegate) return EMappingsTypeFlags::MulticastSparseDelegateProperty;
+		if (Id & EFieldClassID::SoftObject) return EMappingsTypeFlags::SoftObjectProperty;
+		if (Id & EFieldClassID::SoftClass) return EMappingsTypeFlags::SoftClassProperty;
+		if (Id & EFieldClassID::WeakObject) return EMappingsTypeFlags::WeakObjectProperty;
+		if (Id & EFieldClassID::LazyObject) return EMappingsTypeFlags::LazyObjectProperty;
+	}
+
 	return EMappingsTypeFlags::Unknown;
 }
 
@@ -373,10 +428,8 @@ std::stringstream MappingGenerator::GenerateFileData()
 		}
 	}
 
-	/* Combine all of the stringstreams into one Data block representing the entire payload of the file */
 	std::stringstream ReturnBuffer;
 
-	/* Write Name-count and names */
 	WriteToStream(ReturnBuffer, static_cast<uint32>(NameCounter));
 	WriteToStream(ReturnBuffer, NameData);
 

--- a/Dumper/Generator/Public/Generators/DumpspaceGenerator.h
+++ b/Dumper/Generator/Public/Generators/DumpspaceGenerator.h
@@ -17,6 +17,7 @@ class DumpspaceGenerator
 private:
     friend class CppGeneratorTest;
     friend class Generator;
+    friend class JsonSdkGenerator;
 
 private:
     using StreamType = std::ofstream;

--- a/Dumper/Generator/Public/Generators/JsonSdkGenerator.h
+++ b/Dumper/Generator/Public/Generators/JsonSdkGenerator.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Unreal/ObjectArray.h"
+
+#include "Managers/PackageManager.h"
+
+#include "Wrappers/EnumWrapper.h"
+#include "Wrappers/StructWrapper.h"
+
+#include "Dumpspace/DSGen.h"
+
+
+class JsonSdkGenerator
+{
+private:
+	friend class Generator;
+
+private:
+	using StreamType = std::ofstream;
+
+public:
+	static inline PredefinedMemberLookupMapType PredefinedMembers;
+
+	static inline std::string MainFolderName = "SDK";
+	static inline std::string SubfolderName = "";
+
+	static inline fs::path MainFolder;
+	static inline fs::path Subfolder;
+
+private:
+	static nlohmann::json MemberTypeToJson(const DSGen::MemberType& Type);
+	static nlohmann::json MemberToJson(const DSGen::MemberDefinition& Member);
+	static nlohmann::json FunctionToJson(const DSGen::FunctionHolder& Func);
+	static nlohmann::json StructOrClassToJson(const DSGen::ClassHolder& Holder, bool bIsClass);
+	static nlohmann::json EnumToJson(const DSGen::EnumHolder& Holder);
+
+public:
+	static void Generate();
+
+	static void InitPredefinedMembers() { }
+	static void InitPredefinedFunctions() { }
+};

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -7,6 +7,7 @@
 #include "Generators/MappingGenerator.h"
 #include "Generators/IDAMappingGenerator.h"
 #include "Generators/DumpspaceGenerator.h"
+#include "Generators/JsonSdkGenerator.h"
 
 #include "Generators/Generator.h"
 
@@ -65,6 +66,7 @@ DWORD MainThread(HMODULE Module)
 	Generator::Generate<MappingGenerator>();
 	Generator::Generate<IDAMappingGenerator>();
 	Generator::Generate<DumpspaceGenerator>();
+	Generator::Generate<JsonSdkGenerator>();
 
 	auto DumpFinishTime = std::chrono::high_resolution_clock::now();
 


### PR DESCRIPTION
### Add UE5+ support, JSON SDK output, and EFieldClassID fallback

**JsonSdkGenerator – New generator that writes a single SDK.json file to the SDK/ folder with game name, version, structs, enums, and classes (members, offsets, types, functions).**

**UE5+ property types – Support for Utf8StrProperty, AnsiStrProperty, LargeWorldCoordinatesRealProperty, VValueProperty, VRestValueProperty, and VCellProperty in DumpspaceGenerator.**

**EFieldClassID fallback – MappingGenerator uses FieldClass.GetId() when Class is null so FField-based UE5+ properties are handled correctly.**
