### PR TITLE
fix: Increase robustness of function-local static initialization for certain injector behaviors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ mono_crash.*
 /SDKTest/
 
 # Build results
+[Bb]uild/
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/

--- a/Dumper/Generator/Private/Generators/IDAMappingGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/IDAMappingGenerator.cpp
@@ -1,7 +1,13 @@
 
 #include <fstream>
+#include <unordered_map>
 
 #include "Generators/IDAMappingGenerator.h"
+
+namespace
+{
+	std::unordered_map<uint32, std::string> GIdaFuncs;
+}
 
 
 std::string IDAMappingGenerator::MangleFunctionName(const std::string& ClassName, const std::string& FunctionName)
@@ -58,8 +64,6 @@ void IDAMappingGenerator::GenerateVTableName(StreamType& IdmapFile, UEObject Def
 
 void IDAMappingGenerator::GenerateClassFunctions(StreamType& IdmapFile, UEClass Class)
 {
-	static std::unordered_map<uint32, std::string> Funcs;
-
 	for (const UEFunction Func : Class.GetFunctions())
 	{
 		if (!Func.HasFlags(EFunctionFlags::Native))
@@ -70,7 +74,7 @@ void IDAMappingGenerator::GenerateClassFunctions(StreamType& IdmapFile, UEClass 
 		const uint32 Offset = static_cast<uint32>(Platform::GetOffset(Func.GetExecFunction()));
 		const uint16 NameLen = static_cast<uint16>(MangledName.length());
 
-		auto [It, bInseted] = Funcs.emplace(Offset, Func.GetFullName());
+		auto [It, bInseted] = GIdaFuncs.emplace(Offset, Func.GetFullName());
 
 		if (!bInseted)
 		{
@@ -86,6 +90,8 @@ void IDAMappingGenerator::GenerateClassFunctions(StreamType& IdmapFile, UEClass 
 
 void IDAMappingGenerator::Generate()
 {
+	GIdaFuncs.clear();
+
 	std::string IdaMappingFileName = (Settings::Generator::GameVersion + '-' + Settings::Generator::GameName + ".idmap");
 
 	FileNameHelper::MakeValidFileName(IdaMappingFileName);

--- a/Dumper/Generator/Private/Generators/MappingGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/MappingGenerator.cpp
@@ -1,6 +1,7 @@
 
 #include <iostream>
 #include <string>
+#include <unordered_map>
 
 #include "Generators/MappingGenerator.h"
 #include "Managers/PackageManager.h"
@@ -8,6 +9,12 @@
 
 #include "../Settings.h"
 #include "Utils.h"
+
+namespace
+{
+	std::unordered_map<std::string, int32> GNameMap;
+}
+
 
 EMappingsTypeFlags MappingGenerator::GetMappingType(UEProperty Property)
 {
@@ -155,16 +162,14 @@ int32 MappingGenerator::AddNameToData(std::stringstream& NameTable, const std::s
 {
 	if constexpr (Settings::MappingGenerator::bShouldCheckForDuplicatedNames)
 	{
-		static std::unordered_map<std::string, int32> NameMap;
-		
-		auto [It, bInserted] = NameMap.insert({ Name, NameCounter });
+		auto [It, bInserted] = GNameMap.insert({ Name, static_cast<int32>(NameCounter) });
 
 		/* The name didn't occure yet, write it to the NameTable */
 		if (bInserted)
 		{
 			WriteToStream(NameTable, static_cast<uint16>(Name.length()));
 			NameTable.write(Name.c_str(), Name.length());
-			return NameCounter++;
+			return static_cast<int32>(NameCounter++);
 		}
 
 		return It->second;
@@ -173,7 +178,7 @@ int32 MappingGenerator::AddNameToData(std::stringstream& NameTable, const std::s
 	WriteToStream(NameTable, static_cast<uint16>(Name.length()));
 	NameTable.write(Name.c_str(), Name.length());
 
-	return NameCounter++;
+	return static_cast<int32>(NameCounter++);
 }
 
 void MappingGenerator::GeneratePropertyType(UEProperty Property, std::stringstream& Data, std::stringstream& NameTable)
@@ -455,6 +460,8 @@ void MappingGenerator::GenerateFileHeader(StreamType& InUsmap, const std::string
 
 void MappingGenerator::Generate()
 {
+	GNameMap.clear();
+
 	NameCounter = 0x0;
 
 	std::string MappingsFileName = (Settings::Generator::GameVersion + '-' + Settings::Generator::GameName + ".usmap");
@@ -470,4 +477,3 @@ void MappingGenerator::Generate()
 	/* Generate the header, and write both header and payload into the file. */
 	GenerateFileHeader(UsmapFile, FileData);
 }
-


### PR DESCRIPTION
During dump generation, a fatal crash was observed, which was traced back to the initialization of function-local static `std::unordered_map`

<img width="1105" height="510" alt="d60f2ec28e283c91dcde1be28d8bf3fc" src="https://github.com/user-attachments/assets/1fb4a5db-661e-444f-b18c-f1a9d6f05eda" />

Upon further investigation, it appears the root cause is that certain manual-mapping injectors do not properly handle the CRT's initialization routines

---

<img width="980" height="510" alt="b7cc0615db24fd51602dfe27eaf5a9c5" src="https://github.com/user-attachments/assets/c8b50610-4b12-4eb8-bd19-181aada3aa52" />

By moving these variables to file scope, we sidestep the runtime initialization path that requires complex guard logic from the injector