### PR TITLE
Addressed various warnings throughout the project.

### DIFF
--- a/Dumper/Engine/Private/OffsetFinder/OffsetFinder.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/OffsetFinder.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <random>
 
 #include "OffsetFinder/OffsetFinder.h"
 #include "Unreal/ObjectArray.h"
@@ -219,13 +220,27 @@ int32_t OffsetFinder::FindUObjectOuterOffset()
 {
 	int32_t LowestFoundOffset = 0xFFFF;
 
+	const int32 NumObjects = ObjectArray::Num();
+	if (NumObjects < 2)
+		return OffsetNotFound;
+
+	/* Seed with the address of the first object so it varies per game but is deterministic per run. */
+	std::mt19937 Rng(static_cast<uint32_t>(reinterpret_cast<uintptr_t>(ObjectArray::GetByIndex(0).GetAddress())));
+	const int32_t UpperBound = (NumObjects - 1 < 0x3FF) ? (NumObjects - 1) : 0x3FF;
+	std::uniform_int_distribution<int32_t> Dist(0, UpperBound);
+
 	// loop a few times in case we accidentally choose a UPackage (which doesn't have an Outer) to find Outer
 	for (int i = 0; i < 0x10; i++)
 	{
 		int32_t Offset = 0;
 
-		const void* ObjA = ObjectArray::GetByIndex(rand() % 0x400).GetAddress();
-		const void* ObjB = ObjectArray::GetByIndex(rand() % 0x400).GetAddress();
+		const int32_t IndexA = Dist(Rng);
+		int32_t IndexB = Dist(Rng);
+		if (IndexB == IndexA)
+			IndexB = (IndexA + 1) % (UpperBound + 1);
+
+		const void* ObjA = ObjectArray::GetByIndex(IndexA).GetAddress();
+		const void* ObjB = ObjectArray::GetByIndex(IndexB).GetAddress();
 
 		while (Offset != OffsetNotFound)
 		{
@@ -278,7 +293,7 @@ void OffsetFinder::FixupHardcodedOffsets()
 
 		if (IsValidPtr(PossibleNextPtrOrBool0) && IsValidPtr(PossibleNextPtrOrBool1) && IsValidPtr(PossibleNextPtrOrBool2))
 		{
-			std::cerr << "Applaying fix to hardcoded offsets \n" << std::endl;
+			std::cerr << "Applying fix to hardcoded offsets \n" << std::endl;
 
 			Settings::Internal::bUseMaskForFieldOwner = true;
 

--- a/Dumper/Generator/Private/HashStringTable.cpp
+++ b/Dumper/Generator/Private/HashStringTable.cpp
@@ -61,17 +61,17 @@ const StringEntry& HashStringTable::GetStringEntry(int32 BucketIndex, int32 InBu
 
 void HashStringTable::ResizeBucket(StringBucket& Bucket)
 {
-    int32 BucketIdx = &Bucket - Buckets;
+    auto BucketIdx = &Bucket - Buckets;
 
-    const uint32 OldBucketSize = Bucket.Size;
-    const uint64 NewBucketSizeMax = Bucket.SizeMax * 1.5;
+    const auto OldBucketSize = Bucket.Size;
+    const auto NewBucketSizeMax = static_cast<uint64>(Bucket.SizeMax * 1.5);
 
     uint8_t* NewData = static_cast<uint8_t*>(realloc(Bucket.Data, NewBucketSizeMax));
 
     assert(NewData != nullptr && "Realloc failed in function 'ResizeBucket()'.");
 
     Bucket.Data = NewData;
-    Bucket.SizeMax = NewBucketSizeMax;
+    Bucket.SizeMax = static_cast<int32>(NewBucketSizeMax);
 }
 
 template<typename CharType>
@@ -198,12 +198,12 @@ inline std::pair<HashStringTableIndex, bool> HashStringTable::FindOrAdd(const Ch
 /* returns pair<Index, bWasAdded> */
 std::pair<HashStringTableIndex, bool> HashStringTable::FindOrAdd(const std::string& String, bool bShouldMarkAsDuplicated)
 {
-    return FindOrAdd(String.c_str(), String.size(), bShouldMarkAsDuplicated);
+    return FindOrAdd(String.c_str(), static_cast<int32_t>(String.size()), bShouldMarkAsDuplicated);
 }
 
 int32 HashStringTable::GetTotalUsedSize() const
 {
-    uint64 TotalMemoryUsed = 0x0;
+    auto TotalMemoryUsed = 0x0;
 
     for (int i = 0; i < NumBuckets; i++)
     {
@@ -217,8 +217,8 @@ int32 HashStringTable::GetTotalUsedSize() const
 
 void HashStringTable::DebugPrintStats() const
 {
-    uint64 TotalMemoryUsed = 0x0;
-    uint64 TotalMemoryAllocated = 0x0;
+    auto TotalMemoryUsed = 0x0;
+    auto TotalMemoryAllocated = 0x0;
 
     for (int i = 0; i < NumBuckets; i++)
     {

--- a/Dumper/Generator/Private/Managers/CollisionManager.cpp
+++ b/Dumper/Generator/Private/Managers/CollisionManager.cpp
@@ -125,6 +125,47 @@ uint64 CollisionManager::AddNameToContainer(NameContainer& StructNames, UEStruct
 		return false;
 	};
 
+	/*
+	* Checks whether the last entry pushed to TargetContainer has an effective name (as produced by StringifyName)
+	* that conflicts with any earlier entry in the same container. If so, MemberNameCollisionCount is incremented
+	* until the output name is unique. This resolves cases where two properties with different raw names
+	* (e.g. "Params" and "Params_0") both produce the same final output name (e.g. both → "Params_0") after
+	* the reserved-name collision suffix is applied.
+	*/
+	auto ResolveEffectiveNameConflicts = [&](NameContainer* TargetContainer) -> void
+	{
+		if (!TargetContainer || TargetContainer->size() < 2)
+			return;
+
+		NameInfo& NewInfo = TargetContainer->back();
+
+		if (static_cast<ECollisionType>(NewInfo.OwnType) != ECollisionType::MemberName)
+			return;
+
+		const size_t NewInfoIndex = TargetContainer->size() - 1;
+
+		bool bFoundConflict = true;
+		while (bFoundConflict)
+		{
+			bFoundConflict = false;
+
+			const std::string NewOutputName = StringifyName(Struct, NewInfo);
+
+			for (size_t i = 0; i < NewInfoIndex; i++)
+			{
+				if (StringifyName(Struct, (*TargetContainer)[i]) == NewOutputName)
+				{
+					if (NewInfo.MemberNameCollisionCount >= ((1u << PerCountBitCount) - 1))
+						return;
+
+					NewInfo.MemberNameCollisionCount++;
+					bFoundConflict = true;
+					break;
+				}
+			}
+		}
+	};
+
 	const bool bIsParameter = CurrentType == ECollisionType::ParameterName;
 
 	auto [NameIdx, bWasInserted] = NamePair;
@@ -133,6 +174,7 @@ uint64 CollisionManager::AddNameToContainer(NameContainer& StructNames, UEStruct
 	{
 		// Create new empty NameInfo
 		StructNames.emplace_back(NameIdx, CurrentType);
+		ResolveEffectiveNameConflicts(&StructNames);
 		return StructNames.size() - 1;
 	}
 
@@ -179,12 +221,18 @@ uint64 CollisionManager::AddNameToContainer(NameContainer& StructNames, UEStruct
 	{
 		/* Serach ReservedNames last, just in case there was a predefined member of the super-class, or local variable, that collids with it. */
 		if (AddCollidingName(ClassReservedNames, TargetNameContainer, NameIdx, CurrentType, false))
+		{
+			ResolveEffectiveNameConflicts(TargetNameContainer);
 			return TargetNameContainer->size() - 1;
+		}
 	}
 
 	/* Serach ReservedNames last, just in case there was a property in the struct or parent struct, which also collided with a reserved name already */
 	if (AddCollidingName(ReservedNames, TargetNameContainer, NameIdx, CurrentType, false))
+	{
+		ResolveEffectiveNameConflicts(TargetNameContainer);
 		return TargetNameContainer->size() - 1;
+	}
 
 	/* Searching this structs' name list, the super's name list, as well as ReservedNames did not yield any results. No collision on this name, add it! */
 	if (bIsParameter && FuncParamNames)
@@ -195,6 +243,7 @@ uint64 CollisionManager::AddNameToContainer(NameContainer& StructNames, UEStruct
 	else
 	{
 		StructNames.emplace_back(NameIdx, CurrentType);
+		ResolveEffectiveNameConflicts(&StructNames);
 		return StructNames.size() - 1;
 	}
 }

--- a/Dumper/Platform/Private/Arch_x86.cpp
+++ b/Dumper/Platform/Private/Arch_x86.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "Arch_x86.h"
 #include "Platform.h"
 

--- a/Dumper/Platform/Private/PlatformWindows.cpp
+++ b/Dumper/Platform/Private/PlatformWindows.cpp
@@ -20,7 +20,8 @@ namespace
 			return Imagebase != NULL && SectionHeader != nullptr;
 		}
 	};
-	static_assert(sizeof(WindowsSectionInfo) == sizeof(SectionInfo), "To allow interchangable clasting between SectionInfo types you must ensure that the size matches.");
+	static_assert(sizeof(WindowsSectionInfo) == sizeof(SectionInfo), "To allow interchangeable casting between SectionInfo types the sizes must match.");
+	static_assert(std::is_trivially_copyable_v<WindowsSectionInfo> && std::is_trivially_copyable_v<SectionInfo>, "bit_cast between SectionInfo types requires both to be trivially copyable.");
 
 	inline WindowsSectionInfo SectionInfoToWinSectionInfo(const SectionInfo& Info)
 	{
@@ -136,7 +137,8 @@ namespace
 			const LDR_DATA_TABLE_ENTRY* Entry = reinterpret_cast<const LDR_DATA_TABLE_ENTRY*>(P);
 
 			const std::wstring WideModuleName(Entry->BaseDllName.Buffer, Entry->BaseDllName.Length >> 1);
-			const std::string ModuleName = std::string(WideModuleName.begin(), WideModuleName.end());
+			std::string ModuleName(WideModuleName.size(), '\0');
+			std::transform(WideModuleName.begin(), WideModuleName.end(), ModuleName.begin(), [](wchar_t c) { return static_cast<char>(c); });
 
 			if (Utils::StrToLower(ModuleName) == LowercaseSearchModuleName)
 				return Entry;
@@ -227,7 +229,7 @@ namespace
 		const std::string LowercaseSearchModuleName = Utils::StrToLower(ModuleToImportFrom);
 
 		/* Loop all modules and if we found the right one, loop all imports to get the one we need */
-		for (const IMAGE_IMPORT_DESCRIPTOR* Import = ImportTable; Import && Import->Characteristics != 0x0; Import++)
+		for (PIMAGE_IMPORT_DESCRIPTOR Import = ImportTable; Import && Import->Characteristics != 0x0; Import++)
 		{
 			if (Import->Name == 0xFFFF)
 				continue;
@@ -276,7 +278,7 @@ namespace
 		return nullptr;
 	}
 
-	std::pair<uintptr_t, uint32_t> GetSearchStartAndRangeBasedOnOverrides(const uintptr_t ModuleBase, const IMAGE_SECTION_HEADER* SectionHeader, const uintptr_t StartAddress, int32_t Range)
+	std::pair<uintptr_t, ptrdiff_t> GetSearchStartAndRangeBasedOnOverrides(const uintptr_t ModuleBase, const IMAGE_SECTION_HEADER* SectionHeader, const uintptr_t StartAddress, int32_t Range)
 	{
 		if (SectionHeader->VirtualAddress == NULL || SectionHeader->Misc.VirtualSize == 0x0)
 			return { NULL, 0x0 };
@@ -284,7 +286,7 @@ namespace
 		const uintptr_t SectionStartAddress = ModuleBase + SectionHeader->VirtualAddress;
 		const uintptr_t SectionEndAddress = SectionStartAddress + SectionHeader->Misc.VirtualSize;
 
-		uint32_t SearchRange = (Range > 0x0 && Range < SectionHeader->Misc.VirtualSize) ? Range : SectionHeader->Misc.VirtualSize;
+		ptrdiff_t SearchRange = (Range > 0x0 && Range < static_cast<int32_t>(SectionHeader->Misc.VirtualSize)) ? Range : static_cast<ptrdiff_t>(SectionHeader->Misc.VirtualSize);
 		uintptr_t SearchStartAddress = SectionStartAddress;
 
 		// Check if this section contains the StartAddress
@@ -295,7 +297,7 @@ namespace
 				return { NULL, 0x0 };
 
 			SearchStartAddress = StartAddress;
-			SearchRange = SectionEndAddress - StartAddress;
+			SearchRange = static_cast<ptrdiff_t>(SectionEndAddress - StartAddress);
 		}
 
 		return { SearchStartAddress, SearchRange };
@@ -371,9 +373,9 @@ void* WindowsPrivateImplHelper::FindAlignedValueInAllSectionsImpl(const void* Va
 			return false;
 
 		if (Range > 0x0)
-			Range -= SearchRange;
+			Range -= static_cast<int32_t>(SearchRange);
 
-		Result = FinAlignedValueInRangeImpl(ValuePtr, ComparisonFunction, ValueTypeSize, Alignment, SearchStartAddress, SearchRange);
+		Result = FinAlignedValueInRangeImpl(ValuePtr, ComparisonFunction, ValueTypeSize, Alignment, SearchStartAddress, static_cast<uint32_t>(SearchRange));
 
 		return Result != nullptr;
 	};
@@ -390,7 +392,11 @@ uintptr_t PlatformWindows::GetModuleBase(const char* const ModuleName)
 	if (ModuleName == nullptr)
 		return reinterpret_cast<uintptr_t>(GetPEB()->ImageBaseAddress);
 
-	return reinterpret_cast<uintptr_t>(GetModuleLdrTableEntry(ModuleName)->DllBase);
+	const LDR_DATA_TABLE_ENTRY* Entry = GetModuleLdrTableEntry(ModuleName); //This can return nullptr.
+	if (!Entry)
+		return 0x0;
+
+	return reinterpret_cast<uintptr_t>(Entry->DllBase);
 }
 
 uintptr_t PlatformWindows::GetOffset(const uintptr_t Address, const char* const ModuleName)
@@ -425,7 +431,7 @@ void* PlatformWindows::IterateSectionWithCallback(const SectionInfo& Info, const
 		return nullptr;
 
 	const uintptr_t SectionBaseAddrss = WinSectionInfo.Imagebase + WinSectionInfo.SectionHeader->VirtualAddress;
-	const uint32_t SectionIterationSize = GetAlignedSizeWithOffsetFromEnd(WinSectionInfo.SectionHeader->Misc.VirtualSize, Granularity, OffsetFromEnd);
+	const auto SectionIterationSize = GetAlignedSizeWithOffsetFromEnd(WinSectionInfo.SectionHeader->Misc.VirtualSize, Granularity, OffsetFromEnd);
 
 	if (SectionIterationSize == -1)
 		return nullptr;
@@ -472,9 +478,8 @@ bool PlatformWindows::IsAddressInAnyModule(const void* Address)
 	const PEB* Peb = GetPEB();
 	const PEB_LDR_DATA* Ldr = Peb->Ldr;
 
-	int NumEntriesLeft = Ldr->Length;
-
-	for (const LIST_ENTRY* P = Ldr->InMemoryOrderModuleList.Flink; P && NumEntriesLeft-- > 0; P = P->Flink)
+	const LIST_ENTRY* FirstEntry = &Ldr->InMemoryOrderModuleList;
+	for (const LIST_ENTRY* P = Ldr->InMemoryOrderModuleList.Flink; P && P != FirstEntry; P = P->Flink)
 	{
 		const LDR_DATA_TABLE_ENTRY* Entry = reinterpret_cast<const LDR_DATA_TABLE_ENTRY*>(P);
 
@@ -534,9 +539,8 @@ const void* PlatformWindows::GetAddressOfImportedFunctionFromAnyModule(const cha
 	const PEB* Peb = GetPEB();
 	const PEB_LDR_DATA* Ldr = Peb->Ldr;
 
-	int NumEntriesLeft = Ldr->Length;
-
-	for (const LIST_ENTRY* P = Ldr->InMemoryOrderModuleList.Flink; P && NumEntriesLeft-- > 0; P = P->Flink)
+	const LIST_ENTRY* FirstEntry = &Ldr->InMemoryOrderModuleList;
+	for (const LIST_ENTRY* P = Ldr->InMemoryOrderModuleList.Flink; P && P != FirstEntry; P = P->Flink)
 	{
 		const LDR_DATA_TABLE_ENTRY* Entry = reinterpret_cast<const LDR_DATA_TABLE_ENTRY*>(P);
 
@@ -572,7 +576,7 @@ const void* PlatformWindows::GetAddressOfExportedFunction(const char* SearchModu
 	const WORD* Ordinals = reinterpret_cast<const WORD*>(ModuleBase + ExportTable->AddressOfNameOrdinals);
 
 	/* Iterate all names and return the function if the name matches what we're looking for */
-	for (int i = 0; i < ExportTable->NumberOfNames; i++)
+	for (DWORD i = 0; i < ExportTable->NumberOfNames; i++)
 	{
 		const WORD NameIndex = Ordinals[i];
 		const char* Name = reinterpret_cast<const char*>(ModuleBase + NameOffsets[i]);
@@ -608,7 +612,7 @@ std::pair<const void*, int32_t> PlatformWindows::IterateVTableFunctions(void** V
 	if (!CallBackForEachFunc)
 		return { nullptr, -1 };
 
-	for (int i = 0; i < 0x150; i++)
+	for (int i = OffsetFromStart; i < (OffsetFromStart + NumFunctions); i++)
 	{
 		const uintptr_t CurrentFuncAddress = reinterpret_cast<uintptr_t>(VTable[i]);
 
@@ -637,7 +641,7 @@ void* PlatformWindows::FindPattern(const char* Signature, const uint32_t Offset,
 		if (SearchStartAddress == NULL || SearchRange == 0x0)
 			return false;
 
-		Result = FindPatternInRange(Signature, reinterpret_cast<const uint8_t*>(SearchStartAddress), SearchRange, Offset != 0x0, Offset);
+		Result = FindPatternInRange(Signature, reinterpret_cast<const uint8_t*>(SearchStartAddress), static_cast<uintptr_t>(SearchRange), Offset != 0x0, Offset);
 
 		return Result != nullptr;
 	};
@@ -701,10 +705,11 @@ void* PlatformWindows::FindPatternInRange(std::vector<int>&& Signature, const vo
 	const auto PatternLength = static_cast<int64_t>(Signature.size());
 	const auto PatternBytes = Signature.data();
 
+	int CurrentSkips = 0;
+
 	for (int i = 0; i < (static_cast<int64_t>(Range) - PatternLength); i++)
 	{
 		bool bFound = true;
-		int CurrentSkips = 0;
 
 		for (auto j = 0ul; j < PatternLength; ++j)
 		{
@@ -726,7 +731,7 @@ void* PlatformWindows::FindPatternInRange(std::vector<int>&& Signature, const vo
 			if (bRelative)
 			{
 				if (Offset == -1)
-					Offset = PatternLength;
+					Offset = static_cast<uint32_t>(PatternLength);
 
 				Address = ((Address + Offset + 4) + *reinterpret_cast<int32_t*>(Address + Offset));
 			}
@@ -757,12 +762,12 @@ void* PlatformWindows::FindByStringInAllSections(const CharType* RefStr,const ui
 			return false;
 
 		if (Range > 0x0)
-			Range -= SearchRange;
+			Range -= static_cast<int32_t>(SearchRange);
 
 		// Make sure we don't try to read beyond the limit. This might cause string refs at the very end of a search Range not to be found.
 		constexpr auto InstructionBytesLength = 0x7;
 
-		Result = FindStringInRange<bCheckIfLeaIsStrPtr, CharType>(RefStr, SearchStartAddress, (SearchRange - InstructionBytesLength));
+		Result = FindStringInRange<bCheckIfLeaIsStrPtr, CharType>(RefStr, SearchStartAddress, static_cast<int32_t>(SearchRange - InstructionBytesLength));
 
 		return Result != nullptr;
 	};
@@ -818,7 +823,7 @@ inline void* PlatformWindows::FindStringInRange(const CharType* RefStr, const ui
 			if (!IsAddressInProcessRange(StrPtr))
 				continue;
 
-			if (!IsBadReadPtr(StrPtr))
+			if (IsBadReadPtr(StrPtr))
 				continue;
 
 			if (StrnCmpHelper(RefStr, reinterpret_cast<const CharType*>(StrPtr), RefStrLen))

--- a/Dumper/TmpUtils.h
+++ b/Dumper/TmpUtils.h
@@ -44,11 +44,11 @@ inline int32_t StrlenHelper(const CharType* Str)
 {
 	if constexpr (std::is_same<CharType, char>())
 	{
-		return strlen(Str);
+		return static_cast<int32_t>(strlen(Str));
 	}
 	else
 	{
-		return wcslen(Str);
+		return static_cast<int32_t>(wcslen(Str));
 	}
 }
 


### PR DESCRIPTION
Removed unnecessary #pragma once in a CPP file.
Fixed a collision scenario in CollisionManager, where the game had a Member and Member_0, that Member -> Member_0 collided with the static member called Member_0. Fixed typo in WindowsSectionInfo static assert.
Fixed FindPatternInRange's CurrentSkips resetting inside the for loop scope each for loop iteration.

This is the "fix" for colliding names:
<img width="1370" height="300" alt="image" src="https://github.com/user-attachments/assets/86d4d6c2-e348-44e9-a6b1-99d4f6ad70c2" />
<img width="1391" height="362" alt="image" src="https://github.com/user-attachments/assets/90c09b64-a436-48e4-9124-c308ee1ffda4" />

This is how it looked before:

<img width="1378" height="304" alt="image" src="https://github.com/user-attachments/assets/3f731b52-6ed2-4baa-896d-7614b9cb8dfa" />

Branch tested in Release mode on Ready or Not UE5.3.2.0.