### PR TITLE
Cyclic dependency handling for cross package inheritance

### DIFF
--- a/Dumper/Generator/Private/Managers/PackageManager.cpp
+++ b/Dumper/Generator/Private/Managers/PackageManager.cpp
@@ -291,6 +291,8 @@ void PackageManager::InitDependencies()
 				{
 					/* A package can't depend on itself, super of a structs will always be in _"structs" file, same for classes and "_classes" files */
 					RequirementInfo& ReqInfo = PackageDependencyList[SuperPackageIdx];
+					ReqInfo.PackageIdx = SuperPackageIdx;
+
 					BooleanOrEqual(ReqInfo.bShouldIncludeStructs, !bIsClass);
 					BooleanOrEqual(ReqInfo.bShouldIncludeClasses, bIsClass);
 				}
@@ -520,8 +522,10 @@ void PackageManager::HandleCycles()
 
 			DependencyManager::OnVisitCallbackType SetCycleCallback = [PackageIndexWithLeastDependencies, PackageIndexToMarkCyclicWith, bIsStruct](int32 Index) -> void
 			{
-				HelperMarkStructDependenciesOfPackage(ObjectArray::GetByIndex<UEStruct>(Index), PackageIndexToMarkCyclicWith, PackageIndexWithLeastDependencies, !bIsStruct);
+				HelperMarkStructDependenciesOfPackage(ObjectArray::GetByIndex<UEStruct>(Index), PackageIndexWithLeastDependencies, PackageIndexToMarkCyclicWith, !bIsStruct);
 			};
+
+			const DependencyManager& LoserStructsOrClasses = (PackageIndexWithLeastDependencies == PreviousPackageIndex) ? PreviousStructsOrClasses : CurrentStructsOrClasses;
 
 			PreviousStructsOrClasses.VisitAllNodesWithCallback(SetCycleCallback);
 		}


### PR DESCRIPTION
This was tested only on Dead-By-Daylight and nothing else, I would not accept this pr right away without testing first.

In InitDependencies, when a struct/class had a Super in another package, the code adds an entry via 
`"RequirementInfo& ReqInfo = PackageDependencyList[SuperPackageIdx];"` and set the include flags, but never set `ReqInfo.PackageIdx`, leaving it default-initialized to 0. The map key was correct, but the value's mirror field was zero. IterateSingleDependencyImplementation later recursed using `Requirements.PackageIdx`, so every inheritance-derived cross-package edge silently redirected the DFS to package 0 (CoreUObject). The cycle existed in the graph but was unreachable by traversal, so FindCycle reported no cycles and the cycle-fixup template was never emitted.

Fixes:

1. InitDependencies: added the missing `"ReqInfo.PackageIdx = SuperPackageIdx;"`. The DFS now actually traverses inheritance edges.

2. HandleCycles mutual-inclusion branch: the OwnPackageIdx and RequiredPackageIdx arguments to HelperMarkStructDependenciesOfPackage were swapped relative to the non-mutual branch's invariant. The marker was being keyed on the winner package, but codegen queries IsCyclicWithPackage(loserPkg), so nothing ever matched. Swapped to (loser, winner).

3. HandleCycles mutual-inclusion branch: the marking visitor unconditionally iterated PreviousStructsOrClasses, which is only the loser when the dep-count heuristic picks Previous. Added a conditional that picks the actual loser's collection, making the mutual branch structurally consistent with the non-mutual branch.