### PR TITLE
feat: Add Predefined members to FInstancedStruct

### DIFF
--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -438,6 +438,9 @@ void Off::Init()
 	Off::OptionalProperty::ValueProperty = Off::InSDK::Properties::PropertySize;
 
 	Off::ClassProperty::MetaClass = Off::ObjectProperty::PropertyClass + sizeof(void*); //0x8 inheritance from ObjectProperty
+
+	Off::FInstancedStruct::ScriptStruct = 0x00;
+	Off::FInstancedStruct::StructMemory = Off::FInstancedStruct::ScriptStruct + sizeof(void*);
 }
 
 void PropertySizes::Init()

--- a/Dumper/Engine/Public/OffsetFinder/Offsets.h
+++ b/Dumper/Engine/Public/OffsetFinder/Offsets.h
@@ -218,6 +218,12 @@ namespace Off
 		inline int32 ImplementedInterfaces;
 	}
 
+	namespace FInstancedStruct
+	{
+		inline int32 ScriptStruct;
+		inline int32 StructMemory;
+	}
+
 	namespace Property
 	{
 		inline int32 ArrayDim;

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -1956,20 +1956,25 @@ void CppGenerator::InitPredefinedMembers()
 	}
 
 	const UEStruct FInstancedStruct = ObjectArray::FindStructFast("InstancedStruct");
-	PredefinedElements& FInstancedStructPredefs = PredefinedMembers[FInstancedStruct.GetIndex()];
-	FInstancedStructPredefs.Members =
+	if (FInstancedStruct && FInstancedStruct.GetStructSize() >= 0x10)
 	{
-		PredefinedMember {
-			.Comment = "NOT AUTO-GENERATED PROPERTY",
-			.Type = "UScriptStruct*", .Name = "ScriptStruct", .Offset = Off::FInstancedStruct::ScriptStruct, .Size = sizeof(void*), .ArrayDim = 0x1, .Alignment = alignof(void*),
-			.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
-		},
-		PredefinedMember {
-			.Comment = "NOT AUTO-GENERATED PROPERTY",
-			.Type = "uint8*", .Name = "StructMemory", .Offset = Off::FInstancedStruct::StructMemory, .Size = sizeof(void*), .ArrayDim = 0x1, .Alignment = alignof(void*),
-			.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
-		}
-	};
+		PredefinedElements& FInstancedStructPredefs = PredefinedMembers[FInstancedStruct.GetIndex()];
+		FInstancedStructPredefs.Members =
+		{
+			PredefinedMember {
+				.Comment = "NOT AUTO-GENERATED PROPERTY",
+				.Type = "UScriptStruct*", .Name = "ScriptStruct", .Offset = Off::FInstancedStruct::ScriptStruct, .Size = sizeof(void*), .ArrayDim = 0x1, .Alignment = alignof(void*),
+				.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
+			},
+			PredefinedMember {
+				.Comment = "NOT AUTO-GENERATED PROPERTY",
+				.Type = "uint8*", .Name = "StructMemory", .Offset = Off::FInstancedStruct::StructMemory, .Size = sizeof(void*), .ArrayDim = 0x1, .Alignment = alignof(void*),
+				.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
+			}
+		};
+
+		SortMembers(FInstancedStructPredefs.Members);
+	}
 
 	std::string PropertyTypePtr = Settings::Internal::bUseFProperty ? "class FProperty*" : "class UProperty*";
 
@@ -2136,7 +2141,6 @@ void CppGenerator::InitPredefinedMembers()
 	SortMembers(UStructPredefs.Members);
 	SortMembers(UFunctionPredefs.Members);
 	SortMembers(UClassPredefs.Members);
-	SortMembers(FInstancedStructPredefs.Members);
 
 	SortMembers(PropertyMembers);
 	SortMembers(BytePropertyMembers);
@@ -3567,7 +3571,7 @@ namespace InSDKUtils
 class UClass;
 class UObject;
 class UFunction;
-
+class UScriptStruct;
 class FName;
 )";
 

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -1955,6 +1955,22 @@ void CppGenerator::InitPredefinedMembers()
 			});
 	}
 
+	const UEStruct FInstancedStruct = ObjectArray::FindStructFast("InstancedStruct");
+	PredefinedElements& FInstancedStructPredefs = PredefinedMembers[FInstancedStruct.GetIndex()];
+	FInstancedStructPredefs.Members =
+	{
+		PredefinedMember {
+			.Comment = "NOT AUTO-GENERATED PROPERTY",
+			.Type = "UScriptStruct*", .Name = "ScriptStruct", .Offset = Off::FInstancedStruct::ScriptStruct, .Size = sizeof(void*), .ArrayDim = 0x1, .Alignment = alignof(void*),
+			.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
+		},
+		PredefinedMember {
+			.Comment = "NOT AUTO-GENERATED PROPERTY",
+			.Type = "uint8*", .Name = "StructMemory", .Offset = Off::FInstancedStruct::StructMemory, .Size = sizeof(void*), .ArrayDim = 0x1, .Alignment = alignof(void*),
+			.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
+		}
+	};
+
 	std::string PropertyTypePtr = Settings::Internal::bUseFProperty ? "class FProperty*" : "class UProperty*";
 
 	std::vector<PredefinedMember> PropertyMembers =
@@ -2120,6 +2136,7 @@ void CppGenerator::InitPredefinedMembers()
 	SortMembers(UStructPredefs.Members);
 	SortMembers(UFunctionPredefs.Members);
 	SortMembers(UClassPredefs.Members);
+	SortMembers(FInstancedStructPredefs.Members);
 
 	SortMembers(PropertyMembers);
 	SortMembers(BytePropertyMembers);


### PR DESCRIPTION
As the title says, I added predefined members to FInstancedStruct. I hope I added it to the right place.
I haven't checked how long `FInstancedStruct` exists in UE. Would it be smart to add a check?
Like:
```cpp
const UEStruct FInstancedStruct = ObjectArray::FindStructFast("InstancedStruct");
if (FInstancedStruct.GetAddress())
{
}
```