### PR TITLE
Fix UE5.5+: Add Utf8StrProperty/AnsiStrProperty/VCellProperty support, Fix cerr silent failure

### DIFF
--- a/Dumper/Engine/Private/Unreal/UnrealObjects.cpp
+++ b/Dumper/Engine/Private/Unreal/UnrealObjects.cpp
@@ -1067,6 +1067,19 @@ int32 UEProperty::GetAlignment() const
 
 	if (Settings::Internal::bUseFProperty)
 	{
+		if (TypeFlags & EClassCastFlags::Utf8StrProperty)
+		{
+			return alignof(FString); // 0x8, same as StrProperty
+		}
+		else if (TypeFlags & EClassCastFlags::AnsiStrProperty)
+		{
+			return alignof(FString); // 0x8, same as StrProperty
+		}
+		else if (TypeFlags & EClassCastFlags::VCellProperty)
+		{
+			return sizeof(void*); // pointer-sized
+		}
+
 		static std::unordered_map<void*, int32> UnknownProperties;
 
 		static auto TryFindPropertyRefInOptionalToGetAlignment = [](std::unordered_map<void*, int32>& OutProperties, void* PropertyClass) -> int32
@@ -1158,6 +1171,14 @@ std::string UEProperty::GetCppType() const
 		return "class FName";
 	}
 	else if (TypeFlags & EClassCastFlags::StrProperty)
+	{
+		return "class FString";
+	}
+	else if (TypeFlags & EClassCastFlags::Utf8StrProperty)
+	{
+		return "class FString";
+	}
+	else if (TypeFlags & EClassCastFlags::AnsiStrProperty)
 	{
 		return "class FString";
 	}

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -23,6 +23,7 @@ DWORD MainThread(HMODULE Module)
 	AllocConsole();
 	FILE* Dummy;
 	freopen_s(&Dummy, "CONOUT$", "w", stderr);
+	std::cerr.clear(); // clear internal error flags on cerr after redirect
 	freopen_s(&Dummy, "CONIN$", "r", stdin);
 
 	std::cerr << "Initializing [Dumper-7]\n";


### PR DESCRIPTION
## Fix UE5.5+ crash: Add Utf8StrProperty / AnsiStrProperty / VCellProperty support

### Root Cause

The game crashed consistently during `StructManager::InitAlignmentsAndNames()`. After step-by-step debugging, the crash was traced to the `UVerseEnum::QualifiedName` property, whose type is `Utf8StrProperty` (CastFlags = `0x1000000000008001`). This is a new FProperty type introduced in UE5.5 for UTF-8 encoded string properties.

`UEProperty::GetAlignment()` uses a chain of `if/else` branches to identify property types and return their alignment. The original code handled ~30 known types, but did not cover `Utf8StrProperty`, `AnsiStrProperty`, or `VCellProperty` — three new types added in UE5.5+.

When no known type matched, the function fell through to a fallback path that scans the entire ObjectArray (~56,714 structs in this case) searching for an `OptionalProperty` containing the unknown type. This nested full-scan triggered inside the outer property iteration loop, causing the crash.

**Crash chain:**
InitAlignmentsAndNames() iterates all structs
└→ GetAlignment() processes UVerseEnum::QualifiedName (Utf8StrProperty)
└→ 30+ type checks all skipped (no match)
└→ Fallback scan: nested iteration over all 56,714 structs
└→ CRASH



### Changes

**`Dumper/Engine/Private/Unreal/UnrealObjects.cpp`**

1. `GetAlignment()` — Added three new type checks before the FProperty fallback path:
   - `Utf8StrProperty` → `alignof(FString)` (0x8)
   - `AnsiStrProperty` → `alignof(FString)` (0x8)
   - `VCellProperty` → `sizeof(void*)`
2. `GetCppType()` — Added `Utf8StrProperty` and `AnsiStrProperty` returning `class FString`

**`Dumper/main.cpp`**

3. Added `std::cerr.clear()` after `freopen_s` stderr redirect to clear internal error flags that could cause all console output to silently fail.

### Compatibility

Fully backward compatible with UE4.21 - UE5.4. The new type checks are additive and do not alter existing type handling logic.



## 适配 UE5.5+ 新增属性类型，修复 StructManager 初始化阶段崩溃

### 问题定位

在对 UE5.6.1 游戏进行 SDK 生成时，Dumper 在 `StructManager::InitAlignmentsAndNames()` 阶段稳定崩溃。

经过逐层定位，发现崩溃发生在处理 `UVerseEnum::QualifiedName` 属性时。该属性的类型为 `Utf8StrProperty`（CastFlags = `0x1000000000008001`），是 UE5.5 引入的新 FProperty 类型，用于表示 UTF-8 编码的字符串属性。

### 崩溃原因

`UEProperty::GetAlignment()` 函数通过一连串 `if/else` 来判断属性类型并返回对应的对齐值。原代码覆盖了约 30 种已知类型，但没有覆盖 `Utf8StrProperty`、`AnsiStrProperty`、`VCellProperty` 这三种 UE5.5+ 新增类型。

当遇到未匹配的类型时，函数会进入后备路径：遍历全部数万个 ObjectArray 结构体，搜索包含此未知类型的 `OptionalProperty`。这个后备扫描在外部属性迭代的内部触发，形成嵌套的全量遍历，最终导致崩溃。

**崩溃链路：**
InitAlignmentsAndNames() 遍历所有结构体
└→ GetAlignment() 处理 UVerseEnum::QualifiedName (Utf8StrProperty)
└→ 30+ 个类型判断全部跳过（未匹配）
└→ 进入后备扫描：嵌套遍历全部 56,714 个结构体
└→ 崩溃



### 修复内容

**文件：`Dumper/Engine/Private/Unreal/UnrealObjects.cpp`**

1. `GetAlignment()` — 在 FProperty 后备扫描之前，新增三种类型的对齐值返回：
   - `Utf8StrProperty` → `alignof(FString)` (0x8)
   - `AnsiStrProperty` → `alignof(FString)` (0x8)
   - `VCellProperty` → `sizeof(void*)`
2. `GetCppType()` — 新增 `Utf8StrProperty` 和 `AnsiStrProperty` 返回 `class FString`

**文件：`Dumper/main.cpp`**

3. `cerr` 错误标志清除 — 在 `freopen_s` 重定向 stderr 后添加 `std::cerr.clear()`，防止 cerr 内部错误状态导致后续所有控制台输出静默失败。

### 兼容性

向下兼容 UE4.21 - UE5.4。新增的类型判断位于已知类型列表的扩展，不影响已有类型处理逻辑。
