### PR TITLE
Fix UE5.5 Kismet crash, add config overrides and diagnostic logging

### DIFF
--- a/Dumper/Generator/Private/Generators/Generator.cpp
+++ b/Dumper/Generator/Private/Generators/Generator.cpp
@@ -1,5 +1,6 @@
 
 #include "Generators/Generator.h"
+#include "Settings.h"
 #include "Managers/StructManager.h"
 #include "Managers/EnumManager.h"
 #include "Managers/MemberManager.h"
@@ -33,7 +34,7 @@ void Generator::InitEngineCore()
 	//FName::Init(/*AppendString, FName::EOffsetOverrideType::AppendString*/);
 	//FName::Init(/*ToString, FName::EOffsetOverrideType::ToString*/);
 	//FName::Init(/*GNames, FName::EOffsetOverrideType::GNames, true/false*/);
- 
+
 	//Off::InSDK::ProcessEvent::InitPE(/*PEIndex*/);
 
 	/* Back4Blood (requires manual GNames override) */
@@ -42,38 +43,60 @@ void Generator::InitEngineCore()
 	/* Multiversus [Unsupported, weird GObjects-struct] */
 	//InitObjectArrayDecryption([](void* ObjPtr) -> uint8* { return reinterpret_cast<uint8*>(uint64(ObjPtr) ^ 0x1B5DEAFD6B4068C); });
 
+	Settings::Log("[InitEngineCore] ObjectArray::Init()...");
 	ObjectArray::Init();
+	Settings::Log("[InitEngineCore] ObjectArray::Init() done");
 
+	Settings::Log("[InitEngineCore] FName::Init()...");
 	CALL_PLATFORM_SPECIFIC_FUNCTION(FName::Init);
+	Settings::Log("[InitEngineCore] FName::Init() done");
 
+	Settings::Log("[InitEngineCore] Off::Init()...");
 	Off::Init();
+	Settings::Log("[InitEngineCore] Off::Init() done");
+
+	Settings::Log("[InitEngineCore] PropertySizes::Init()...");
 	PropertySizes::Init();
+	Settings::Log("[InitEngineCore] PropertySizes::Init() done");
 
+	Settings::Log("[InitEngineCore] Off::InSDK::ProcessEvent::InitPE()...");
 	CALL_PLATFORM_SPECIFIC_FUNCTION(Off::InSDK::ProcessEvent::InitPE); // Must be at this position, relies on offsets initialized in Off::Init()
+	Settings::Log("[InitEngineCore] Off::InSDK::ProcessEvent::InitPE() done");
 
+	Settings::Log("[InitEngineCore] Off::InSDK::World::InitGWorld()...");
 	Off::InSDK::World::InitGWorld(); // Must be at this position, relies on offsets initialized in Off::Init()
+	Settings::Log("[InitEngineCore] Off::InSDK::World::InitGWorld() done");
 
+	Settings::Log("[InitEngineCore] Off::InSDK::Text::InitTextOffsets()...");
 	Off::InSDK::Text::InitTextOffsets(); // Must be at this position, relies on offsets initialized in Off::InitPE()
+	Settings::Log("[InitEngineCore] Off::InSDK::Text::InitTextOffsets() done");
 
+	Settings::Log("[InitEngineCore] InitSettings()...");
 	InitSettings();
+	Settings::Log("[InitEngineCore] InitSettings() done");
 }
 
 void Generator::InitInternal()
 {
-	// Initialize PackageManager with all packages, their names, structs, classes enums, functions and dependencies
+	Settings::Log("[InitInternal] PackageManager::Init()...");
 	PackageManager::Init();
+	Settings::Log("[InitInternal] PackageManager::Init() done");
 
-	// Initialize StructManager with all structs and their names
+	Settings::Log("[InitInternal] StructManager::Init()...");
 	StructManager::Init();
-	
-	// Initialize EnumManager with all enums and their names
-	EnumManager::Init();
-	
-	// Initialized all Member-Name collisions
-	MemberManager::Init();
+	Settings::Log("[InitInternal] StructManager::Init() done");
 
-	// Post-Initialize PackageManager after StructManager has been initialized. 'PostInit()' handles Cyclic-Dependencies detection
+	Settings::Log("[InitInternal] EnumManager::Init()...");
+	EnumManager::Init();
+	Settings::Log("[InitInternal] EnumManager::Init() done");
+
+	Settings::Log("[InitInternal] MemberManager::Init()...");
+	MemberManager::Init();
+	Settings::Log("[InitInternal] MemberManager::Init() done");
+
+	Settings::Log("[InitInternal] PackageManager::PostInit()...");
 	PackageManager::PostInit();
+	Settings::Log("[InitInternal] PackageManager::PostInit() done");
 }
 
 bool Generator::SetupDumperFolder()

--- a/Dumper/Settings.cpp
+++ b/Dumper/Settings.cpp
@@ -3,6 +3,9 @@
 #include <Windows.h>
 #include <filesystem>
 #include <string>
+#include <fstream>
+#include <cstdarg>
+#include <mutex>
 
 #include "Unreal/UnrealObjects.h"
 #include "Unreal/ObjectArray.h"
@@ -202,6 +205,27 @@ void Settings::Config::Load()
 			std::cerr << "Press " << KeyName << " to begin dump." << "\n";
 		}
 	}
+
+	char GameNameBuf[256] = {};
+	GetPrivateProfileStringA("Settings", "GameName", "", GameNameBuf, sizeof(GameNameBuf), ConfigPath);
+	if (GameNameBuf[0] != '\0')
+	{
+		Settings::Generator::GameName = GameNameBuf;
+	}
+
+	char GameVersionBuf[256] = {};
+	GetPrivateProfileStringA("Settings", "GameVersion", "", GameVersionBuf, sizeof(GameVersionBuf), ConfigPath);
+	if (GameVersionBuf[0] != '\0')
+	{
+		Settings::Generator::GameVersion = GameVersionBuf;
+	}
+
+	Settings::Debug::bEnableDiagnosticLogging = GetPrivateProfileIntA("Debug", "bEnableDiagnosticLogging", 0, ConfigPath) != 0;
+	Settings::Debug::bEnableVectoredCrashHandler = GetPrivateProfileIntA("Debug", "bEnableVectoredCrashHandler", 0, ConfigPath) != 0;
+
+	char LogPathBuf[256] = {};
+	GetPrivateProfileStringA("Debug", "DiagnosticLogPath", "Dumper-7-debug.log", LogPathBuf, sizeof(LogPathBuf), ConfigPath);
+	Settings::Debug::DiagnosticLogPath = LogPathBuf;
 }
 
 void Settings::Config::DelayDumperStart()
@@ -235,6 +259,62 @@ void Settings::Config::DelayDumperStart()
 			
 		Sleep(50);
 	}
+}
+
+static std::ofstream DiagnosticLogStream;
+static std::mutex LogMutex;
+
+static std::string GetModuleDirectory()
+{
+	char path[MAX_PATH];
+	HMODULE hModule = nullptr;
+	GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCSTR)&GetModuleDirectory, &hModule);
+	if (hModule && GetModuleFileNameA(hModule, path, MAX_PATH))
+	{
+		std::string s(path);
+		size_t pos = s.find_last_of("\\/");
+		if (pos != std::string::npos)
+		{
+			return s.substr(0, pos);
+		}
+	}
+	return "";
+}
+
+void Settings::Log(const std::string& Message)
+{
+	std::lock_guard<std::mutex> Lock(LogMutex);
+
+	std::cerr << Message << std::endl;
+
+	if (Settings::Debug::bEnableDiagnosticLogging)
+	{
+		if (!DiagnosticLogStream.is_open())
+		{
+			std::filesystem::path LogPath = Settings::Debug::DiagnosticLogPath;
+			if (LogPath.is_relative())
+			{
+				LogPath = std::filesystem::path(GetModuleDirectory()) / LogPath;
+			}
+			
+			DiagnosticLogStream.open(LogPath, std::ios::out | std::ios::trunc);
+		}
+
+		if (DiagnosticLogStream.is_open())
+		{
+			DiagnosticLogStream << Message << std::endl;
+		}
+	}
+}
+
+void Settings::LogFmt(const char* Format, ...)
+{
+	char Buffer[1024];
+	va_list Args;
+	va_start(Args, Format);
+	vsnprintf(Buffer, sizeof(Buffer), Format, Args);
+	va_end(Args);
+	Log(Buffer);
 }
 
 

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -124,6 +124,15 @@ R"(
 
 		/* Prints debug information during Mapping-Generation */
 		inline constexpr bool bShouldPrintMappingDebugData = false;
+
+		/* Enables diagnostic file logging (Dumper-7-debug.log) */
+		inline bool bEnableDiagnosticLogging = false;
+
+		/* Enables Vectored Exception Handler (VEH) to catch and log crashes prior to process exit */
+		inline bool bEnableVectoredCrashHandler = false;
+
+		/* Path to diagnostic log file, relative or absolute. If empty, logs next to the DLL. */
+		inline std::string DiagnosticLogPath = "Dumper-7-debug.log";
 	}
 
 	//* * * * * * * * * * * * * * * * * * * * *// 
@@ -179,4 +188,7 @@ R"(
 
 	extern void InitObjectPtrPropertySettings();
 	extern void InitArrayDimSizeSettings();
+
+	extern void Log(const std::string& Message);
+	extern void LogFmt(const char* Format, ...);
 }

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -3,11 +3,11 @@
 #include <chrono>
 #include <fstream>
 
+#include "Settings.h"
 #include "Generators/CppGenerator.h"
 #include "Generators/MappingGenerator.h"
 #include "Generators/IDAMappingGenerator.h"
 #include "Generators/DumpspaceGenerator.h"
-
 #include "Generators/Generator.h"
 
 enum class EFortToastType : uint8
@@ -18,79 +18,141 @@ enum class EFortToastType : uint8
         EFortToastType_MAX             = 3,
 };
 
+// ── Vectored exception handler ─────────────────────────────────────────────
+// Runs before the default crash handler, giving us a chance to flush the log.
+static LONG WINAPI VEH_CrashHandler(EXCEPTION_POINTERS* pEx)
+{
+	// Ignore non-fatal exceptions like C++ exceptions in-flight or STATUS_BREAKPOINT
+	DWORD code = pEx->ExceptionRecord->ExceptionCode;
+	if (code == 0xE06D7363 /*C++ exception*/ || code == EXCEPTION_BREAKPOINT)
+		return EXCEPTION_CONTINUE_SEARCH;
+
+	Settings::LogFmt("\n!!! CRASH: exception code=0x%08X at address=0x%p",
+		code, pEx->ExceptionRecord->ExceptionAddress);
+
+	// Log parameters (helpful for access violations: [0]=read/write flag, [1]=bad address)
+	for (DWORD i = 0; i < pEx->ExceptionRecord->NumberParameters && i < 4; i++)
+		Settings::LogFmt("    ExceptionInformation[%lu] = 0x%llX", i, (unsigned long long)pEx->ExceptionRecord->ExceptionInformation[i]);
+
+	return EXCEPTION_CONTINUE_SEARCH; // let the normal crash dialog appear
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
 DWORD MainThread(HMODULE Module)
 {
 	AllocConsole();
 	FILE* Dummy;
 	freopen_s(&Dummy, "CONOUT$", "w", stderr);
-	std::cerr.clear(); // clear internal error flags on cerr after redirect
+	std::cerr.clear();
 	freopen_s(&Dummy, "CONIN$", "r", stdin);
 
-	std::cerr << "Initializing [Dumper-7]\n";
+	Settings::Log("Initializing [Dumper-7]");
 
 	Settings::Config::Load();
-	Settings::Config::DelayDumperStart();
-	
-	std::cerr << "Started Generation [Dumper-7]!\n";
-	auto DumpStartTime = std::chrono::high_resolution_clock::now();
+	Settings::Log("[Config] Load() done");
 
-	Generator::InitEngineCore();
-	Generator::InitInternal();
-
-	if (Settings::Generator::GameName.empty() && Settings::Generator::GameVersion.empty())
+	// Install exception handler if enabled in config
+	PVOID vehHandle = nullptr;
+	if (Settings::Debug::bEnableVectoredCrashHandler)
 	{
-		// Only Possible in Main()
-		FString Name;
-		FString Version;
-		UEClass Kismet = ObjectArray::FindClassFast("KismetSystemLibrary");
-		UEFunction GetGameName = Kismet.GetFunction("KismetSystemLibrary", "GetGameName");
-		UEFunction GetEngineVersion = Kismet.GetFunction("KismetSystemLibrary", "GetEngineVersion");
-
-		Kismet.ProcessEvent(GetGameName, &Name);
-		Kismet.ProcessEvent(GetEngineVersion, &Version);
-
-		Settings::Generator::GameName = Name.ToString();
-		Settings::Generator::GameVersion = Version.ToString();
+		vehHandle = AddVectoredExceptionHandler(1 /*first in chain*/, VEH_CrashHandler);
+		Settings::Log("[Debug] Vectored exception handler installed");
 	}
 
-	std::cerr << "GameName: " << Settings::Generator::GameName << "\n";
-	std::cerr << "GameVersion: " << Settings::Generator::GameVersion << "\n\n";
+	Settings::Config::DelayDumperStart();
+	Settings::Log("[Config] DelayDumperStart() done");
 
-	std::cerr << "FolderName: " << (Settings::Generator::GameVersion + '-' + Settings::Generator::GameName) << "\n\n";
+	Settings::Log("Started Generation [Dumper-7]!");
+	auto DumpStartTime = std::chrono::high_resolution_clock::now();
 
+	// ── InitEngineCore ────────────────────────────────────────────────────
+	Settings::Log("[Step] >>> Generator::InitEngineCore()");
+	Generator::InitEngineCore();
+	Settings::Log("[Step] <<< Generator::InitEngineCore() complete");
+
+	// ── InitInternal ──────────────────────────────────────────────────────
+	Settings::Log("[Step] >>> Generator::InitInternal()");
+	Generator::InitInternal();
+	Settings::Log("[Step] <<< Generator::InitInternal() complete");
+
+	// ── Game name / version ───────────────────────────────────────────────
+	if (Settings::Generator::GameName.empty() && Settings::Generator::GameVersion.empty())
+	{
+		UEClass Kismet = ObjectArray::FindClassFast("KismetSystemLibrary");
+		if (Kismet)
+		{
+			UEFunction GetGameName = Kismet.GetFunction("KismetSystemLibrary", "GetGameName");
+			UEFunction GetEngineVersion = Kismet.GetFunction("KismetSystemLibrary", "GetEngineVersion");
+
+			if (GetGameName && GetEngineVersion)
+			{
+				FString Name;
+				FString Version;
+				__try
+				{
+					Kismet.ProcessEvent(GetGameName, &Name);
+					Kismet.ProcessEvent(GetEngineVersion, &Version);
+
+					Settings::Generator::GameName = Name.ToString();
+					Settings::Generator::GameVersion = Version.ToString();
+				}
+				__except (EXCEPTION_EXECUTE_HANDLER)
+				{
+					Settings::Log("[Warning] Crashed while attempting to auto-detect GameName and GameVersion via KismetSystemLibrary ProcessEvent.");
+				}
+			}
+		}
+
+		if (Settings::Generator::GameName.empty())
+			Settings::Generator::GameName = "UE-Game";
+		if (Settings::Generator::GameVersion.empty())
+			Settings::Generator::GameVersion = "UnknownVersion";
+	}
+
+	Settings::LogFmt("GameName: %s", Settings::Generator::GameName.c_str());
+	Settings::LogFmt("GameVersion: %s", Settings::Generator::GameVersion.c_str());
+	Settings::LogFmt("FolderName: %s", (Settings::Generator::GameVersion + '-' + Settings::Generator::GameName).c_str());
+
+	// ── Generate ──────────────────────────────────────────────────────────
+	Settings::Log("[Step] >>> Generator::Generate<CppGenerator>()");
 	Generator::Generate<CppGenerator>();
+	Settings::Log("[Step] <<< CppGenerator done");
+
+	Settings::Log("[Step] >>> Generator::Generate<MappingGenerator>()");
 	Generator::Generate<MappingGenerator>();
+	Settings::Log("[Step] <<< MappingGenerator done");
+
+	Settings::Log("[Step] >>> Generator::Generate<IDAMappingGenerator>()");
 	Generator::Generate<IDAMappingGenerator>();
+	Settings::Log("[Step] <<< IDAMappingGenerator done");
+
+	Settings::Log("[Step] >>> Generator::Generate<DumpspaceGenerator>()");
 	Generator::Generate<DumpspaceGenerator>();
+	Settings::Log("[Step] <<< DumpspaceGenerator done");
 
 	auto DumpFinishTime = std::chrono::high_resolution_clock::now();
-
 	std::chrono::duration<double, std::milli> DumpTime = DumpFinishTime - DumpStartTime;
-
-	std::cerr << "\n\nGenerating SDK took (" << DumpTime.count() << "ms)\n\n\n";
+	Settings::LogFmt("Generating SDK took (%.1fms)", DumpTime.count());
 
 	if (Settings::Debug::bExecuteSDKTestScript)
 	{
-		/* Executes a python script to test if the SDK compiles correctly. */
+		Settings::Log("[Step] Executing SDK compilation test script...");
 		CppGenerator::ExecuteSDKCompilationTestScript();
 	}
 
-	std::cerr << "\n\nPress F6 to unload\n\n\n";
+	Settings::Log("=== Generation complete. Press F6 to unload. ===");
+
+	if (vehHandle) RemoveVectoredExceptionHandler(vehHandle);
 
 	while (true)
 	{
 		if (GetAsyncKeyState(VK_F6) & 1)
 		{
 			fclose(stderr);
-			if (Dummy) 
-			{
-				fclose(Dummy);
-			}
+			if (Dummy) fclose(Dummy);
 			FreeConsole();
-
 			FreeLibraryAndExitThread(Module, 0);
 		}
-
 		Sleep(100);
 	}
 


### PR DESCRIPTION
Injecting into Unreal Engine 5.5.4.1 games like Borderlands 4 causes a fatal crash when calling ProcessEvent on KismetSystemLibrary to retrieve game metadata. This PR introduces a graceful SEH fallback, configurable bypass, and vectored exception logging to assist in troubleshooting.