### PR TITLE
Fix #447: dispatch BlueprintEvent calls through FindFunctionChecked

### DIFF
--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -84,6 +84,63 @@ void Off::InSDK::ProcessEvent::InitPE(const int32 Index, const char* const Modul
 	std::cerr << std::format("PE-Offset: 0x{:X}\n", Off::InSDK::ProcessEvent::PEOffset);
 }
 
+void Off::InSDK::Find::InitFindFunctionChecked()
+{
+	const void* StringRefAddr = Platform::FindByStringInAllSections<false, wchar_t>(L"Failed to find function %s in %s", 0x0, 0x0, Settings::General::bSearchOnlyExecutableSectionsForStrings);
+
+	if (!StringRefAddr)
+		StringRefAddr = Platform::FindByStringInAllSections<true, wchar_t>(L"Failed to find function %s in %s", 0x0, 0x0, Settings::General::bSearchOnlyExecutableSectionsForStrings);
+
+	if (!StringRefAddr)
+	{
+		std::cerr << "\nCouldn't find 'Failed to find function %s in %s' string-ref!\n\n";
+		return;
+	}
+
+	DWORD64 ImageBase = 0;
+	PRUNTIME_FUNCTION FunctionEntry = RtlLookupFunctionEntry(reinterpret_cast<DWORD64>(StringRefAddr), &ImageBase, nullptr);
+
+	if (!FunctionEntry)
+	{
+		std::cerr << "\nCouldn't recover FindFunctionChecked entry from string-ref!\n\n";
+		return;
+	}
+
+	struct UnwindInfoHeader
+	{
+		uint8_t VersionAndFlags;
+		uint8_t SizeOfProlog;
+		uint8_t CountOfCodes;
+		uint8_t FrameRegisterAndOffset;
+	};
+
+	constexpr uint8_t UnwFlagChainInfoMask = 0x20;
+
+	for (int ChainDepth = 0; ChainDepth < 16; ++ChainDepth)
+	{
+		const uintptr_t UnwindInfoAddr = static_cast<uintptr_t>(ImageBase) + FunctionEntry->UnwindData;
+		if (Platform::IsBadReadPtr(reinterpret_cast<void*>(UnwindInfoAddr)))
+			break;
+
+		const UnwindInfoHeader* Header = reinterpret_cast<const UnwindInfoHeader*>(UnwindInfoAddr);
+		if (!(Header->VersionAndFlags & UnwFlagChainInfoMask))
+			break;
+
+		const uint32_t AlignedCodeCount = (Header->CountOfCodes + 1u) & ~1u;
+		const uintptr_t ChainedEntryAddr = UnwindInfoAddr + sizeof(UnwindInfoHeader) + AlignedCodeCount * sizeof(uint16_t);
+
+		if (Platform::IsBadReadPtr(reinterpret_cast<void*>(ChainedEntryAddr)))
+			break;
+
+		FunctionEntry = reinterpret_cast<PRUNTIME_FUNCTION>(ChainedEntryAddr);
+	}
+
+	const uintptr_t FuncStart = static_cast<uintptr_t>(ImageBase) + FunctionEntry->BeginAddress;
+
+	Off::InSDK::Find::FindFunctionCheckedOffset = Platform::GetOffset(reinterpret_cast<void*>(FuncStart));
+	std::cerr << std::format("Off::InSDK::Find::FindFunctionChecked: 0x{:X}\n\n", Off::InSDK::Find::FindFunctionCheckedOffset);
+}
+
 /* UWorld */
 void Off::InSDK::World::InitGWorld()
 {

--- a/Dumper/Engine/Public/OffsetFinder/Offsets.h
+++ b/Dumper/Engine/Public/OffsetFinder/Offsets.h
@@ -102,6 +102,13 @@ namespace Off
 		{
 			inline int32 RowMap;
 		}
+
+		namespace Find
+		{
+			inline int32 FindFunctionCheckedOffset = -1;
+
+			void InitFindFunctionChecked();
+		}
 	}
 
 	namespace FUObjectArray

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -424,6 +424,31 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 	std::string FixedOuterName = PrefixQuotsWithBackslash(UnrealFunc.GetOuter().GetName());
 	std::string FixedFunctionName = PrefixQuotsWithBackslash(UnrealFunc.GetName());
 
+	const bool bUseDynamicLookup = Off::InSDK::Find::FindFunctionCheckedOffset > 0
+		&& Func.HasFunctionFlag(EFunctionFlags::BlueprintEvent)
+		&& !Func.IsStatic();
+
+	std::string FuncLookupBlock;
+	if (bUseDynamicLookup)
+	{
+		FuncLookupBlock = std::format(
+R"(	static class FName FnName;
+	class UFunction* Func = InSDKUtils::FindFunctionChecked({}, GetStaticName(L"{}", FnName));)",
+			Func.IsInInterface() ? "AsUObject()" : "this",
+			FixedFunctionName);
+	}
+	else
+	{
+		FuncLookupBlock = std::format(
+R"(	static class UFunction* Func = nullptr;
+
+	if (Func == nullptr)
+		Func = {}->GetFunction({}, {});)",
+			Func.IsStatic() ? "StaticClass()" : Func.IsInInterface() ? "AsUObject()->Class" : "Class",
+			CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedOuterName) : std::format("\"{}\"", FixedOuterName),
+			CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedFunctionName) : std::format("\"{}\"", FixedFunctionName));
+	}
+
 	// Function implementation generation
 	std::string FunctionImplementation = std::format(R"(
 // {}
@@ -431,10 +456,7 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 {}
 {} {}::{}{}
 {{
-	static class UFunction* Func = nullptr;
-
-	if (Func == nullptr)
-		Func = {}->GetFunction({}, {});
+{}
 {}{}{}
 	{}ProcessEvent(Func, {});{}{}{}{}
 }}
@@ -446,9 +468,7 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 , StructName
 , FuncInfo.FuncNameWithParams
 , bIsConstFunc ? " const" : ""
-, Func.IsStatic() ? "StaticClass()" : Func.IsInInterface() ? "AsUObject()->Class" : "Class"
-, CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedOuterName) : std::format("\"{}\"", FixedOuterName)
-, CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedFunctionName) : std::format("\"{}\"", FixedFunctionName)
+, FuncLookupBlock
 , bHasParams ? ParamVarCreationString : ""
 , bHasParamsToInit ? ParamAssignments : ""
 , bIsNativeFunc ? StoreFunctionFlagsString : ""
@@ -3576,12 +3596,13 @@ using namespace UC;
 */
 namespace Offsets
 {{
-	constexpr int32 GObjects          = 0x{:08X};
-	constexpr int32 AppendString      = 0x{:08X};{}
-	constexpr int32 GNames            = 0x{:08X};
-	constexpr int32 GWorld            = 0x{:08X};
-	constexpr int32 ProcessEvent      = 0x{:08X};
-	constexpr int32 ProcessEventIdx   = 0x{:08X};
+	constexpr int32 GObjects             = 0x{:08X};
+	constexpr int32 AppendString         = 0x{:08X};{}
+	constexpr int32 GNames               = 0x{:08X};
+	constexpr int32 GWorld               = 0x{:08X};
+	constexpr int32 ProcessEvent         = 0x{:08X};
+	constexpr int32 ProcessEventIdx      = 0x{:08X};
+	constexpr int32 FindFunctionChecked  = 0x{:08X};
 }}
 )", max(Off::InSDK::ObjArray::GObjects, 0x0),
 	max(Off::InSDK::Name::AppendNameToString, 0x0),
@@ -3589,8 +3610,18 @@ namespace Offsets
 	max(Off::InSDK::NameArray::GNames, 0x0),
 	max(Off::InSDK::World::GWorld, 0x0),
 	max(Off::InSDK::ProcessEvent::PEOffset, 0x0),
-	Off::InSDK::ProcessEvent::PEIndex);
+	Off::InSDK::ProcessEvent::PEIndex,
+	max(Off::InSDK::Find::FindFunctionCheckedOffset, 0x0));
 
+
+	BasicHpp << R"(
+// Forward declarations because in-line forward declarations make the compiler think 'GetStaticClass()' is a class template
+class UClass;
+class UObject;
+class UFunction;
+class UScriptStruct;
+class FName;
+)";
 
 	// Start Namespace 'InSDKUtils'
 	BasicHpp <<
@@ -3614,6 +3645,28 @@ namespace InSDKUtils
 	}
 )";
 
+	if (Off::InSDK::Find::FindFunctionCheckedOffset > 0)
+	{
+		if (Settings::Internal::bUseCasePreservingName)
+		{
+			BasicHpp << R"(	inline class UFunction* FindFunctionChecked(const class UObject* Obj, const class FName& Name)
+	{
+		using FFindFunctionCheckedFn = class UFunction*(__fastcall*)(const class UObject*, const class FName*);
+		return reinterpret_cast<FFindFunctionCheckedFn>(GetImageBase() + Offsets::FindFunctionChecked)(Obj, &Name);
+	}
+)";
+		}
+		else
+		{
+			BasicHpp << R"(	inline class UFunction* FindFunctionChecked(const class UObject* Obj, const class FName& Name)
+	{
+		using FFindFunctionCheckedFn = class UFunction*(__fastcall*)(const class UObject*, uint64);
+		return reinterpret_cast<FFindFunctionCheckedFn>(GetImageBase() + Offsets::FindFunctionChecked)(Obj, *reinterpret_cast<const uint64*>(&Name));
+	}
+)";
+		}
+	}
+
 	//Customizable part of Cpp code to allow for a custom 'CallGameFunction' function
 	BasicHpp << CppSettings::CallGameFunction;
 
@@ -3623,15 +3676,6 @@ namespace InSDKUtils
 	/* Custom 'GetImageBase' function */
 	BasicCpp << std::format(R"(uintptr_t InSDKUtils::GetImageBase()
 {})", Settings::CppGenerator::GetImageBaseFuncBody);
-
-	BasicHpp << R"(
-// Forward declarations because in-line forward declarations make the compiler think 'GetStaticClass()' is a class template
-class UClass;
-class UObject;
-class UFunction;
-class UScriptStruct;
-class FName;
-)";
 
 	BasicHpp << R"(
 namespace BasicFilesImplUtils

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -440,10 +440,10 @@ R"(	static class FName FnName;
 	else
 	{
 		FuncLookupBlock = std::format(
-R"(	static class UFunction* Func = nullptr;
-
-	if (Func == nullptr)
-		Func = {}->GetFunction({}, {});)",
+R"(	static int32 FuncIdx = 0;
+	static uint64 FuncFName = 0;
+	static uint64 OuterFName = 0;
+	class UFunction* Func = GetStaticFunction({}, {}, {}, FuncIdx, FuncFName, OuterFName);)",
 			Func.IsStatic() ? "StaticClass()" : Func.IsInInterface() ? "AsUObject()->Class" : "Class",
 			CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedOuterName) : std::format("\"{}\"", FixedOuterName),
 			CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedFunctionName) : std::format("\"{}\"", FixedFunctionName));
@@ -3694,6 +3694,10 @@ namespace BasicFilesImplUtils
 
 	UFunction* FindFunctionByFName(const FName* Name);
 
+	UFunction* FindFunctionViaClass(UClass* SearchClass, const char* OuterClassName, const char* FuncName);
+
+	uint64 GetObjectOuterFNameAsUInt64(UObject* Obj);
+
 	FName StringToName(const wchar_t* Name);
 
 	UObject* GetDefaultObjectImpl(UClass* ClassInstance);
@@ -3745,6 +3749,19 @@ UFunction* BasicFilesImplUtils::FindFunctionByFName(const FName* Name)
 	}
 
 	return nullptr;
+}
+
+UFunction* BasicFilesImplUtils::FindFunctionViaClass(UClass* SearchClass, const char* OuterClassName, const char* FuncName)
+{
+	return SearchClass->GetFunction(OuterClassName, FuncName);
+}
+
+uint64 BasicFilesImplUtils::GetObjectOuterFNameAsUInt64(UObject* Obj)
+{
+	if (!Obj || !Obj->Outer)
+		return 0;
+
+	return *reinterpret_cast<uint64*>(&Obj->Outer->Name);
 }
 
 FName BasicFilesImplUtils::StringToName(const wchar_t* Name)
@@ -3840,6 +3857,35 @@ class UClass* GetStaticBPGeneratedClass(const char* Name, int32& ClassIdx, uint6
 
 		return ClassObj;
 	}
+}
+)";
+
+	BasicHpp << R"(
+inline class UFunction* GetStaticFunction(class UClass* SearchClass, const char* OuterClassName, const char* FuncName, int32& FuncIdx, uint64& FuncFName, uint64& OuterFName)
+{
+	static auto SetFuncIndex = [](class UFunction* Fn, int32& Idx, uint64& Name, uint64& OuterName) -> class UFunction*
+	{
+		if (Fn)
+		{
+			Idx = BasicFilesImplUtils::GetObjectIndex(reinterpret_cast<class UClass*>(Fn));
+			Name = BasicFilesImplUtils::GetObjFNameAsUInt64(reinterpret_cast<class UClass*>(Fn));
+			OuterName = BasicFilesImplUtils::GetObjectOuterFNameAsUInt64(reinterpret_cast<class UObject*>(Fn));
+		}
+
+		return Fn;
+	};
+
+	if (FuncIdx == 0x0) [[unlikely]]
+		return SetFuncIndex(BasicFilesImplUtils::FindFunctionViaClass(SearchClass, OuterClassName, FuncName), FuncIdx, FuncFName, OuterFName);
+
+	class UFunction* FnObj = reinterpret_cast<class UFunction*>(BasicFilesImplUtils::GetObjectByIndex(FuncIdx));
+
+	if (!FnObj
+		|| BasicFilesImplUtils::GetObjFNameAsUInt64(reinterpret_cast<class UClass*>(FnObj)) != FuncFName
+		|| BasicFilesImplUtils::GetObjectOuterFNameAsUInt64(reinterpret_cast<class UObject*>(FnObj)) != OuterFName)
+		return SetFuncIndex(BasicFilesImplUtils::FindFunctionViaClass(SearchClass, OuterClassName, FuncName), FuncIdx, FuncFName, OuterFName);
+
+	return FnObj;
 }
 )";
 

--- a/Dumper/Generator/Private/Generators/Generator.cpp
+++ b/Dumper/Generator/Private/Generators/Generator.cpp
@@ -51,6 +51,8 @@ void Generator::InitEngineCore()
 
 	CALL_PLATFORM_SPECIFIC_FUNCTION(Off::InSDK::ProcessEvent::InitPE); // Must be at this position, relies on offsets initialized in Off::Init()
 
+	Off::InSDK::Find::InitFindFunctionChecked();
+
 	Off::InSDK::World::InitGWorld(); // Must be at this position, relies on offsets initialized in Off::Init()
 
 	Off::InSDK::Text::InitTextOffsets(); // Must be at this position, relies on offsets initialized in Off::InitPE()


### PR DESCRIPTION
Bug

Generated wrappers cache a static UFunction* from Class->GetFunction("OuterName", "FuncName"). Two problems:

- "OuterName" is hardcoded at dump time, so the SuperStruct walk skips derived BP classes that override the function and you get the base's UFunction*, not the override.
- The static cache is shared across every instance of every class that calls the wrapper, so even if you fix the lookup, the first caller's class wins forever.

Anything BlueprintImplementableEvent / BlueprintNativeEvent overridden in a BP subclass is affected.

Fix

For UFunctions flagged BlueprintEvent (and not Static), the wrapper now resolves the UFunction* on every call through the engine's own UObject::FindFunctionChecked(FName):

void UMyBase::SomeEvent() {
    static FName FnName;
    UFunction* Func = InSDKUtils::FindFunctionChecked(this, GetStaticName(L"SomeEvent", FnName));
    UObject::ProcessEvent(Func, &Parms);
}

The FName is still cached (FName indices are stable), but the UFunction* isn't, it gets resolved per-call on the actual instance's Class, so each derived BP gets its own override. This hits the engine's per-class TMap cache (AllFunctionsCache on UE5, SuperFuncMap on UE4), so per-call cost is low roughly ~10ns and it's the same path UE itself uses for EX_VirtualFunction in the BP VM.

Non-overridable functions (pure native, Static, RPCs, delegates) keep the existing static-cached path, so there's no performance change for ~85-95% of wrappers.

Finding FindFunctionChecked

Sigscan L"Failed to find function %s in %s" it's present in every release(4.0.1 through 5.8). We try direct LEA first, then if it fails falls back to indirect-LEA-to-pointer-table for UE5's logger. The xref lands inside the function, so we recover the entry with RtlLookupFunctionEntry and walk UNW_FLAG_CHAININFO back to the primary RUNTIME_FUNCTION, this is needed because MSVC's shrink-wrap optimizer splits UE5 shipping funcs across multiple .pdata entries.

If the sigscan fails (stripped strings), the offset stays at -1 and codegen quietly falls back to the legacy static cache. SDK still builds, just doesn't fix overrides.
                                                                                                                                                               The FName ABI differs between UE4 (by-value uint64) and UE5 case-preserving (by-reference). Codegen picks based on Settings::Internal::bUseCasePreservingName.

I tested on two games and it worked perfectly:

- One Armed Cook (UE4.27) I chose BP wrappers  for UpdateSunDirection() / RefreshMaterial() called on a live BP_Sky_Sphere_C instance. No crash, dispatch correct, repeat calls fine and most importantly the function worked fine.

- DBD (UE5.6) For my test dll I cannot go past the main menu so I called FindFunctionChecked(obj, name) on 10 functions and it returned the same UFunction* as a hand-written walk would.

I've also checked to see if it was thread-safe, on every UE version checked (4.27 through 5.8), UE itself calls this path from async loading, and task-graph threads via the BP VM.