### PR TITLE
UE5.4.4+ GNames failure fallback with appendstring

### DIFF
--- a/Dumper/Engine/Private/Unreal/NameArray.cpp
+++ b/Dumper/Engine/Private/Unreal/NameArray.cpp
@@ -501,6 +501,67 @@ bool NameArray::TryFindNamePool_Windows()
 #endif // PLATFORM_WINDOWS
 }
 
+/*
+ * Finds GFNamePool by scanning FName::AppendString's prologue for the lazy-init pattern
+ *
+ * UE 5.4.4+ inlines the NamePool init at every AppendString site, producing a 'lea r8, GFNamePool' /
+ * 'lea rcx, GFNamePool' pair within a few bytes of each other. TryFindNamePool_Windows can't see
+ * GFNamePool because modern UE has no standalone FNamePool::FNamePool constructor matching its
+ * lea+call signature.
+*/
+bool NameArray::TryFindNamePoolLazyInit_Windows()
+{
+#ifdef PLATFORM_WINDOWS
+
+	if (Off::InSDK::Name::AppendNameToString == 0x0)
+		return false;
+
+	const uintptr_t AppendStringAddress = Platform::GetModuleBase() + Off::InSDK::Name::AppendNameToString;
+
+	constexpr int32 ScanRange = 0x80;
+	constexpr int32 PairSearchWindow = 0x20;
+
+	const uint8* Begin = reinterpret_cast<const uint8*>(AppendStringAddress);
+	const uint8* End = Begin + ScanRange - PairSearchWindow;
+
+	for (const uint8* Bytes = Begin; Bytes < End; Bytes++)
+	{
+		const bool bIsLeaR8 = Bytes[0] == 0x4C && Bytes[1] == 0x8D && Bytes[2] == 0x05;
+		const bool bIsLeaRcx = Bytes[0] == 0x48 && Bytes[1] == 0x8D && Bytes[2] == 0x0D;
+
+		if (!bIsLeaR8 && !bIsLeaRcx)
+			continue;
+
+		const uintptr_t TargetA = Architecture_x86_64::Resolve32BitRelativeLea(reinterpret_cast<uintptr_t>(Bytes));
+
+		if (!Platform::IsAddressInWritableSection(TargetA))
+			continue;
+
+		for (int i = 0x7; i < PairSearchWindow; i++)
+		{
+			const uint8* PairBytes = Bytes + i;
+
+			const bool bPairIsLeaR8 = bIsLeaRcx && PairBytes[0] == 0x4C && PairBytes[1] == 0x8D && PairBytes[2] == 0x05;
+			const bool bPairIsLeaRcx = bIsLeaR8 && PairBytes[0] == 0x48 && PairBytes[1] == 0x8D && PairBytes[2] == 0x0D;
+
+			if (!bPairIsLeaR8 && !bPairIsLeaRcx)
+				continue;
+
+			const uintptr_t TargetB = Architecture_x86_64::Resolve32BitRelativeLea(reinterpret_cast<uintptr_t>(PairBytes));
+
+			if (TargetB != TargetA)
+				continue;
+
+			Off::InSDK::NameArray::GNames = Platform::GetOffset(TargetA);
+			return true;
+		}
+	}
+
+	return false;
+
+#endif // PLATFORM_WINDOWS
+}
+
 bool NameArray::TryInit(bool bIsTestOnly)
 {
 	const uintptr_t ImageBase = Platform::GetModuleBase();
@@ -516,6 +577,13 @@ bool NameArray::TryInit(bool bIsTestOnly)
 		GNamesAddress = *reinterpret_cast<uint8**>(ImageBase + Off::InSDK::NameArray::GNames);// Derefernce
 		Settings::Internal::bUseNamePool = false;
 		bFoundNameArray = true;
+	}
+	else if (CALL_PLATFORM_SPECIFIC_FUNCTION(NameArray::TryFindNamePoolLazyInit))
+	{
+		std::cerr << std::format("Found 'FNamePool GNames' (lazy-init) at offset 0x{:X}\n", Off::InSDK::NameArray::GNames) << std::endl;
+		GNamesAddress = reinterpret_cast<uint8*>(ImageBase + Off::InSDK::NameArray::GNames);
+		Settings::Internal::bUseNamePool = true;
+		bFoundnamePool = true;
 	}
 	else if (CALL_PLATFORM_SPECIFIC_FUNCTION(NameArray::TryFindNamePool))
 	{
@@ -620,6 +688,12 @@ bool NameArray::SetGNamesWithoutCommitting()
 	{
 		std::cerr << std::format("Found 'TNameEntryArray GNames' at offset 0x{:X}\n", Off::InSDK::NameArray::GNames) << std::endl;
 		Settings::Internal::bUseNamePool = false;
+		return true;
+	}
+	else if (CALL_PLATFORM_SPECIFIC_FUNCTION(NameArray::TryFindNamePoolLazyInit))
+	{
+		std::cerr << std::format("Found 'FNamePool GNames' (lazy-init) at offset 0x{:X}\n", Off::InSDK::NameArray::GNames) << std::endl;
+		Settings::Internal::bUseNamePool = true;
 		return true;
 	}
 	else if (CALL_PLATFORM_SPECIFIC_FUNCTION(NameArray::TryFindNamePool))

--- a/Dumper/Engine/Public/Unreal/NameArray.h
+++ b/Dumper/Engine/Public/Unreal/NameArray.h
@@ -53,6 +53,7 @@ public:
 	/* Should be changed later and combined */
 	static bool TryFindNameArray_Windows();
 	static bool TryFindNamePool_Windows();
+	static bool TryFindNamePoolLazyInit_Windows();
 
 	static bool TryInit(bool bIsTestOnly = false);
 	static bool TryInit(int32 OffsetOverride, bool bIsNamePool, const char* const ModuleName = Settings::General::DefaultModuleName);

--- a/Dumper/Platform/Private/PlatformWindows.cpp
+++ b/Dumper/Platform/Private/PlatformWindows.cpp
@@ -297,7 +297,9 @@ namespace
 				return { NULL, 0x0 };
 
 			SearchStartAddress = StartAddress;
-			SearchRange = static_cast<ptrdiff_t>(SectionEndAddress - StartAddress);
+
+			const ptrdiff_t RemainingInSection = static_cast<ptrdiff_t>(SectionEndAddress - StartAddress);
+			SearchRange = (Range > 0x0 && Range < RemainingInSection) ? Range : RemainingInSection;
 		}
 
 		return { SearchStartAddress, SearchRange };
@@ -419,7 +421,7 @@ SectionInfo PlatformWindows::GetSectionInfo(const std::string& SectionName, cons
 		{
 			return reinterpret_cast<const char*>(Section->Name) == SectionName;
 		});
-	
+
 	return WinSectionInfoToSectionInfo(WinSectionInfo);
 }
 
@@ -502,6 +504,14 @@ bool PlatformWindows::IsAddressInProcessRange(const uintptr_t Address)
 bool PlatformWindows::IsAddressInProcessRange(const void* Address)
 {
 	return IsAddressInProcessRange(reinterpret_cast<uintptr_t>(Address));
+}
+bool PlatformWindows::IsAddressInWritableSection(const uintptr_t Address)
+{
+	return IsInAnySection(Address, IMAGE_SCN_MEM_WRITE);
+}
+bool PlatformWindows::IsAddressInWritableSection(const void* Address)
+{
+	return IsAddressInWritableSection(reinterpret_cast<uintptr_t>(Address));
 }
 bool PlatformWindows::IsBadReadPtr(const uintptr_t Address)
 {

--- a/Dumper/Platform/Private/PlatformWindows.h
+++ b/Dumper/Platform/Private/PlatformWindows.h
@@ -132,6 +132,8 @@ namespace PlatformWindows
 	bool IsAddressInAnyModule(const void* Address);
 	bool IsAddressInProcessRange(const uintptr_t Address);
 	bool IsAddressInProcessRange(const void* Address);
+	bool IsAddressInWritableSection(const uintptr_t Address);
+	bool IsAddressInWritableSection(const void* Address);
 	bool IsBadReadPtr(const uintptr_t Address);
 	bool IsBadReadPtr(const void* Address);
 


### PR DESCRIPTION
Apparently, GNames fails on multiple 5.4.4+ games, so I added a fallback if it fails.

Tested on "Dead By Daylight-5.6.1" and "Subnatica-5.6.1"