### PR TITLE
Proper interface support: multiple inheritance + re-emitted dispatch methods

### DIFF
--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <array>
+#include <unordered_set>
 
 #include "Unreal/ObjectArray.h"
 #include "Generators/CppGenerator.h"
@@ -62,6 +63,119 @@ std::string CppGenerator::GenerateBytePadding(const int32 Offset, const int32 Pa
 std::string CppGenerator::GenerateBitPadding(uint8 UnderlayingSizeBytes, const uint8 PrevBitPropertyEndBit, const int32 Offset, const int32 PadSize, std::string&& Reason)
 {
 	return MakeMemberString(GetTypeFromSize(UnderlayingSizeBytes), std::format("BitPad_{:X}_{:X} : {:d}", Offset, PrevBitPropertyEndBit, PadSize), std::format("0x{:04X}(0x{:04X})({})", Offset, UnderlayingSizeBytes, std::move(Reason)));
+}
+
+void CppGenerator::EnsureInterfaceVftMember(UEClass InterfaceClass)
+{
+	if (!InterfaceClass)
+		return;
+
+	PredefinedElements& Predefs = PredefinedMembers[InterfaceClass.GetIndex()];
+
+	for (const PredefinedMember& Existing : Predefs.Members)
+	{
+		if (Existing.Name == "Vft")
+			return;
+	}
+
+	PredefinedMember VftMember = {
+		.Comment = "NOT AUTO-GENERATED PROPERTY",
+		.Type = "void*", .Name = "Vft",
+		.Offset = 0x0, .Size = sizeof(void*),
+		.ArrayDim = 0x1, .Alignment = alignof(void*),
+		.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
+	};
+
+	Predefs.Members.push_back(std::move(VftMember));
+}
+
+CppGenerator::InterfaceMILayout CppGenerator::ComputeInterfaceMI(const StructWrapper& Struct, int32 UnalignedSuperSize)
+{
+	InterfaceMILayout Layout;
+
+	if (!Struct.IsUnrealStruct() || !Struct.IsClass() || Struct.IsInterface())
+		return Layout;
+
+	if (Struct.IsVerseGeneratedClass())
+	{
+		Layout.FallbackReason = "Verse class, PointerOffset=0 for all entries";
+		return Layout;
+	}
+
+	std::vector<FImplementedInterface> Natives = Struct.GetNativeInterfaces();
+	if (Natives.empty())
+		return Layout;
+
+	constexpr int32 InterfaceVftSize = static_cast<int32>(sizeof(void*));
+	int32 Cursor = (UnalignedSuperSize + (InterfaceVftSize - 1)) & ~(InterfaceVftSize - 1);
+
+	Layout.Entries.reserve(Natives.size());
+	for (const FImplementedInterface& Iface : Natives)
+	{
+		const int32 EngineOffset = Iface.PointerOffset;
+		const int32 PaddingNeeded = EngineOffset - Cursor;
+
+		if (PaddingNeeded < 0)
+		{
+			Layout.FallbackReason = std::format("iface '{}' at 0x{:X} precedes cursor 0x{:X}", Iface.InterfaceClass.GetName(), EngineOffset, Cursor);
+			Layout.Entries.clear();
+			return Layout;
+		}
+
+		Layout.Entries.push_back({
+			.Interface = Iface.InterfaceClass,
+			.PaddingBefore = PaddingNeeded,
+			.PaddingTag = EngineOffset
+		});
+
+		Cursor = EngineOffset + InterfaceVftSize;
+		Layout.TotalMIBytes += PaddingNeeded + InterfaceVftSize;
+	}
+
+	Layout.bIsViable = true;
+	return Layout;
+}
+
+std::string CppGenerator::GetInterfaceInheritanceString(const InterfaceMILayout& Layout)
+{
+	std::string Out;
+
+	for (const InterfaceMILayout::Entry& E : Layout.Entries)
+	{
+		if (!E.Interface)
+			continue;
+
+		if (E.PaddingBefore > 0)
+			Out += std::format(", public MIPad::Pad<0x{:X}, 0x{:X}>", E.PaddingBefore, E.PaddingTag);
+
+		Out += ", public ";
+		Out += GetStructPrefixedName(StructWrapper(E.Interface.Cast<UEStruct>()));
+	}
+
+	return Out;
+}
+
+void CppGenerator::EmitInterfaceMIStaticAsserts(const StructWrapper& Struct, const InterfaceMILayout& Layout, const std::string& UniqueName, StreamType& StructFile)
+{
+	if (!Layout.bIsViable || Layout.Entries.empty() || !Struct.IsUnrealStruct())
+		return;
+
+	StructFile << "#ifdef _MSC_VER\n";
+	StructFile << "#pragma warning(push)\n";
+	StructFile << "#pragma warning(disable: 4316)\n";
+	StructFile << "#pragma warning(disable: 5046)\n";
+
+	for (const FImplementedInterface& Iface : Struct.GetUnrealStruct().Cast<UEClass>().GetImplementedInterfaces())
+	{
+		if (Iface.bImplementedByK2 || !Iface.InterfaceClass)
+			continue;
+
+		const std::string IfacePrefixed = GetStructPrefixedName(StructWrapper(Iface.InterfaceClass.Cast<UEStruct>()));
+		StructFile << std::format("static_assert(offsetof({0}, {1}::Vft) == 0x{2:04X}, \"Wrong interface VFT offset for '{0}::{1}'\");\n", UniqueName, IfacePrefixed, Iface.PointerOffset);
+	}
+
+	StructFile << "#pragma warning(pop)\n";
+	StructFile << "#endif\n";
 }
 
 std::string CppGenerator::GenerateMembers(const StructWrapper& Struct, const MemberManager& Members, int32 SuperSize, int32 SuperLastMemberEnd, int32 SuperAlign, int32 PackageIndex)
@@ -293,7 +407,7 @@ CppGenerator::FunctionInfo CppGenerator::GenerateFunctionInfo(const FunctionWrap
 	return RetFuncInfo;
 }
 
-std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, const std::string& StructName, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile)
+std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, const std::string& StructName, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile, bool bForceImplementerDispatch)
 {
 	namespace CppSettings = Settings::CppGenerator;
 
@@ -337,9 +451,14 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 
 	std::string ParamStructName = Func.GetParamStructName();
 
-	// Parameter struct generation for unreal-functions
 	if (!Func.IsPredefined() && Func.GetParamStructSize() > 0x0)
-		GenerateStruct(Func.AsStruct(), ParamFile, FunctionFile, ParamFile, AssertionFile, -1, ParamStructName);
+	{
+		static std::unordered_set<std::string> EmittedParamStructs;
+		const std::string DedupKey = std::format("{:X}|{}", reinterpret_cast<uintptr_t>(&ParamFile), ParamStructName);
+		
+		if (EmittedParamStructs.insert(DedupKey).second)
+			GenerateStruct(Func.AsStruct(), ParamFile, FunctionFile, ParamFile, AssertionFile, -1, ParamStructName);
+	}
 
 
 	std::string ParamVarCreationString = std::format(R"(
@@ -424,6 +543,34 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 	std::string FixedOuterName = PrefixQuotsWithBackslash(UnrealFunc.GetOuter().GetName());
 	std::string FixedFunctionName = PrefixQuotsWithBackslash(UnrealFunc.GetName());
 
+	const bool bDispatchAsInterface = Func.IsInInterface() && !bForceImplementerDispatch;
+
+	/* Pending #531: re-enable once Off::InSDK::Find::FindFunctionCheckedOffset is on main */
+#if 0
+	const bool bUseDynamicLookup = Off::InSDK::Find::FindFunctionCheckedOffset > 0
+		&& !Func.IsStatic() && (Func.HasFunctionFlag(EFunctionFlags::BlueprintEvent) || bForceImplementerDispatch);
+
+	std::string FuncLookupBlock;
+	if (bUseDynamicLookup)
+	{
+		FuncLookupBlock = std::format(
+R"(	static class FName FnName;
+	class UFunction* Func = InSDKUtils::FindFunctionChecked({}, GetStaticName(L"{}", FnName));)",
+			bDispatchAsInterface ? "AsUObject()" : "this",
+			FixedFunctionName);
+	}
+	else
+	{
+		FuncLookupBlock = std::format(
+R"(	static int32 FuncIdx = 0;
+	static uint64 FuncFName = 0;
+	static uint64 OuterFName = 0;
+	class UFunction* Func = GetStaticFunction({}, {}, {}, FuncIdx, FuncFName, OuterFName);)",
+			Func.IsStatic() ? "StaticClass()" : bDispatchAsInterface ? "AsUObject()->Class" : "Class",
+			CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedOuterName) : std::format("\"{}\"", FixedOuterName),
+			CppSettings::XORString ? std::format("{}(\"{}\")", CppSettings::XORString, FixedFunctionName) : std::format("\"{}\"", FixedFunctionName));
+	}
+#endif
 	// Function implementation generation
 	std::string FunctionImplementation = std::format(R"(
 // {}
@@ -452,7 +599,7 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 , bHasParams ? ParamVarCreationString : ""
 , bHasParamsToInit ? ParamAssignments : ""
 , bIsNativeFunc ? StoreFunctionFlagsString : ""
-, Func.IsStatic() ? "GetDefaultObj()->" : Func.IsInInterface() ? "AsUObject()->" : "UObject::"
+, Func.IsStatic() ? "GetDefaultObj()->" : bDispatchAsInterface ? "AsUObject()->" : "UObject::"
 , bHasParams ? "&Parms" : "nullptr"
 , bIsNativeFunc ? RestoreFunctionFlagsString : ""
 , bHasOutRefParamsToInit ? OutRefAssignments : ""
@@ -464,7 +611,7 @@ std::string CppGenerator::GenerateSingleFunction(const FunctionWrapper& Func, co
 	return InHeaderFunctionText;
 }
 
-std::string CppGenerator::GenerateFunctions(const StructWrapper& Struct, const MemberManager& Members, const std::string& StructName, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile)
+std::string CppGenerator::GenerateFunctions(const StructWrapper& Struct, const MemberManager& Members, const std::string& StructName, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile, bool bEmitMIInterfaceOverride)
 {
 	namespace CppSettings = Settings::CppGenerator;
 
@@ -639,6 +786,54 @@ R"({{
 		InHeaderFunctionText += GenerateSingleFunction(FunctionWrapper(CurrentStructPtr, &Interface_AsObject), StructName, FunctionFile, ParamFile, AssertionFile);
 		InHeaderFunctionText += GenerateSingleFunction(FunctionWrapper(CurrentStructPtr, &Interface_AsObject_Const), StructName, FunctionFile, ParamFile, AssertionFile);
 	}
+	else if (bEmitMIInterfaceOverride)
+	{
+		std::unordered_set<std::string> AlreadyEmitted;
+		for (const FunctionWrapper& Own : Members.IterateFunctions())
+		{
+			if (Own.GetFunctionFlags() & EFunctionFlags::Delegate)
+				continue;
+			AlreadyEmitted.insert(Own.GetName());
+		}
+		for (const PropertyWrapper& Prop : Members.IterateMembers())
+			AlreadyEmitted.insert(Prop.GetName());
+
+		bool bWroteSectionHeader = false;
+		for (const FImplementedInterface& Iface : Struct.GetNativeInterfaces())
+		{
+			for (UEStruct IfaceStruct = Iface.InterfaceClass.Cast<UEStruct>(); IfaceStruct; IfaceStruct = IfaceStruct.GetSuper())
+			{
+				StructWrapper IfaceWrapper(IfaceStruct);
+				if (!IfaceWrapper.IsInterface())
+					break;
+
+				std::shared_ptr<StructWrapper> IfacePtr = std::make_shared<StructWrapper>(IfaceWrapper);
+				MemberManager IfaceMembers = IfaceWrapper.GetMembers();
+
+				for (const FunctionWrapper& IfaceFunc : IfaceMembers.IterateFunctions())
+				{
+					if (IfaceFunc.GetFunctionFlags() & EFunctionFlags::Delegate)
+						continue;
+
+					UEFunction RawFn = IfaceFunc.GetUnrealFunction();
+					if (!RawFn)
+						continue;
+
+					FunctionWrapper Rebound(IfacePtr, RawFn);
+					if (!AlreadyEmitted.insert(Rebound.GetName()).second)
+						continue;
+
+					if (!bWroteSectionHeader)
+					{
+						InHeaderFunctionText += "\npublic:\n";
+						bWroteSectionHeader = true;
+					}
+
+					InHeaderFunctionText += GenerateSingleFunction(Rebound, StructName, FunctionFile, ParamFile, AssertionFile, true);
+				}
+			}
+		}
+	}
 
 	return InHeaderFunctionText;
 }
@@ -660,7 +855,20 @@ void CppGenerator::GenerateStruct(const StructWrapper& Struct, StreamType& Struc
 
 	StructWrapper Super = Struct.GetSuper();
 
-	const bool bHasValidSuper = Super.IsValid() && !Struct.IsFunction() && !Struct.IsInterface();
+	const bool bIsThisInterface = Struct.IsInterface();
+
+	bool bInterfaceHasParentInterface = false;
+	if (bIsThisInterface && Super.IsValid() && Super.IsInterface())
+	{
+		static UEClass AbstractInterfaceClass = ObjectArray::FindClassFast("Interface");
+		if (Super.IsUnrealStruct() && Super.GetUnrealStruct() != AbstractInterfaceClass)
+			bInterfaceHasParentInterface = true;
+	}
+
+	if (bIsThisInterface && !bInterfaceHasParentInterface && Struct.IsUnrealStruct())
+		EnsureInterfaceVftMember(Struct.GetUnrealStruct().Cast<UEClass>());
+
+	const bool bHasValidSuper = Super.IsValid() && !Struct.IsFunction() && (!bIsThisInterface || bInterfaceHasParentInterface);
 
 	/* Ignore UFunctions with a valid Super field, parameter structs are not supposed inherit from eachother. */
 	if (bHasValidSuper)
@@ -686,6 +894,18 @@ void CppGenerator::GenerateStruct(const StructWrapper& Struct, StreamType& Struc
 
 	const bool bIsTemplatedType = Struct.HasCustomTemplateText();
 
+	InterfaceMILayout IfaceMI;
+	if (!bIsThisInterface && bHasValidSuper)
+		IfaceMI = ComputeInterfaceMI(Struct, UnalignedSuperSize);
+
+	const std::string IfaceInheritanceStr = GetInterfaceInheritanceString(IfaceMI);
+
+	std::string FallbackComment;
+	if (!IfaceMI.bIsViable && !IfaceMI.FallbackReason.empty() && Struct.IsUnrealStruct() && !bIsThisInterface && Struct.HasNativeInterfaces())
+	{
+		FallbackComment = "// [interface MI fallback] " + IfaceMI.FallbackReason + "\n";
+	}
+
 	std::string AlignmentString = "";
 
 	if (Struct.ShouldUseExplicitAlignment())
@@ -696,19 +916,20 @@ void CppGenerator::GenerateStruct(const StructWrapper& Struct, StreamType& Struc
 	StructFile << std::format(R"(
 // {}
 // 0x{:04X} (0x{:04X} - 0x{:04X})
-{}{}{} {}{}{}{}
+{}{}{}{} {}{}{}{}
 {{
 )", Struct.GetFullName()
   , StructSizeWithoutSuper
   , StructSize
   , SuperSize
   , bHasReusedTrailingPadding ? "#pragma pack(push, 0x1)\n" : ""
+  , FallbackComment
   , bIsTemplatedType ? (Struct.GetCustomTemplateText() + "\n") : ""
   , bIsClass ? "class" : (bIsUnion ? "union" : "struct")
   , AlignmentString
   , UniqueName
   , Settings::CppGenerator::bAddFinalSpecifier && Struct.IsFinal() ? " final" : ""
-  , bHasValidSuper ? (" : public " + UniqueSuperName) : "");
+  , bHasValidSuper ? (" : public " + UniqueSuperName + IfaceInheritanceStr) : "");
 
 	MemberManager Members = Struct.GetMembers();
 
@@ -720,9 +941,13 @@ void CppGenerator::GenerateStruct(const StructWrapper& Struct, StreamType& Struc
 	if (bHasMembers || bHasFunctions)
 		StructFile << "public:\n";
 
+	const int32 MIBaseBytes = IfaceMI.bIsViable ? IfaceMI.TotalMIBytes : 0;
+
 	if (bHasMembers)
 	{
-		StructFile << GenerateMembers(Struct, Members, bIsReusingTrailingPaddingFromSuper ? UnalignedSuperSize : SuperSize, SuperLastMemberEnd, SuperAlignment, PackageIndex);
+		const int32 MemberSuperSize = (bIsReusingTrailingPaddingFromSuper ? UnalignedSuperSize : SuperSize) + MIBaseBytes;
+		const int32 MemberLastMemberEnd = SuperLastMemberEnd + MIBaseBytes;
+		StructFile << GenerateMembers(Struct, Members, MemberSuperSize, MemberLastMemberEnd, SuperAlignment, PackageIndex);
 
 		if (bHasFunctions)
 			StructFile << "\npublic:\n";
@@ -732,13 +957,15 @@ void CppGenerator::GenerateStruct(const StructWrapper& Struct, StreamType& Struc
 	{
 		StreamType& FuncParamsAssertionFile = Settings::Debug::bGenerateAssertionFile ? AssertionFile : ParamFile;
 
-		StructFile << GenerateFunctions(Struct, Members, UniqueName, FunctionFile, ParamFile, FuncParamsAssertionFile);
+		StructFile << GenerateFunctions(Struct, Members, UniqueName, FunctionFile, ParamFile, FuncParamsAssertionFile, IfaceMI.bIsViable);
 	}
 
 	StructFile << "};\n";
 
 	if (bHasReusedTrailingPadding)
 		StructFile << "#pragma pack(pop)\n";
+
+	EmitInterfaceMIStaticAsserts(Struct, IfaceMI, UniqueName, StructFile);
 
 	if constexpr (Settings::Debug::bGenerateAssertionFile)
 	{
@@ -1568,6 +1795,9 @@ void CppGenerator::WriteFileHead(StreamType& File, PackageInfoHandle Package, EF
 
 			if (Requirements.bShouldIncludeClasses)
 				File << std::format("#include \"{}_classes.hpp\"\n", DependencyName);
+
+			if (Requirements.bShouldIncludeParameters)
+				File << std::format("#include \"{}_parameters.hpp\"\n", DependencyName);
 		}
 
 		if (bAddNewLine)
@@ -3591,6 +3821,21 @@ namespace Offsets
 	max(Off::InSDK::ProcessEvent::PEOffset, 0x0),
 	Off::InSDK::ProcessEvent::PEIndex);
 
+
+	BasicHpp << R"(
+// Forward declarations because in-line forward declarations make the compiler think 'GetStaticClass()' is a class template
+class UClass;
+class UObject;
+class UFunction;
+class UScriptStruct;
+class FName;
+
+namespace MIPad
+{
+	template<unsigned long long N, unsigned long long Tag>
+	struct alignas(1) Pad { unsigned char _pad[N]; };
+}
+)";
 
 	// Start Namespace 'InSDKUtils'
 	BasicHpp <<

--- a/Dumper/Generator/Private/Managers/PackageManager.cpp
+++ b/Dumper/Generator/Private/Managers/PackageManager.cpp
@@ -298,6 +298,28 @@ void PackageManager::InitDependencies()
 				}
 			}
 
+			if (bIsClass)
+			{
+				for (const FImplementedInterface& Iface : ObjAsStruct.Cast<UEClass>().GetImplementedInterfaces())
+				{
+					if (Iface.bImplementedByK2 || !Iface.InterfaceClass)
+						continue;
+
+					const int32 IfacePackageIdx = Iface.InterfaceClass.GetPackageIndex();
+
+					if (IfacePackageIdx == StructPackageIdx)
+					{
+						ClassOrStructDependencyList.AddDependency(Obj.GetIndex(), Iface.InterfaceClass.GetIndex());
+					}
+					else
+					{
+						RequirementInfo& ReqInfo = PackageDependencyList[IfacePackageIdx];
+						ReqInfo.PackageIdx = IfacePackageIdx;
+						BooleanOrEqual(ReqInfo.bShouldIncludeClasses, true);
+					}
+				}
+			}
+
 			if (!bIsClass)
 				continue;
 			
@@ -315,6 +337,43 @@ void PackageManager::InitDependencies()
 				/* Add dependencies to ParamDependencies and add enums only to class dependencies (forwarddeclaration of enum classes defaults to int) */
 				PackageManagerUtils::SetPackageDependencies(Info.PackageDependencies.ParametersDependencies, ParamDependencies, FuncPackageIndex, true);
 				PackageManagerUtils::AddEnumPackageDependencies(Info.PackageDependencies.ClassesDependencies, ParamDependencies, FuncPackageIndex, true);
+			}
+
+			for (const FImplementedInterface& Iface : ObjAsStruct.Cast<UEClass>().GetImplementedInterfaces())
+			{
+				if (Iface.bImplementedByK2 || !Iface.InterfaceClass)
+					continue;
+
+				for (UEStruct IfaceStruct = Iface.InterfaceClass.Cast<UEStruct>(); IfaceStruct; IfaceStruct = IfaceStruct.GetSuper())
+				{
+					if (!IfaceStruct.IsA(EClassCastFlags::Class))
+						break;
+						
+					static const UEClass InterfaceBaseClass = ObjectArray::FindClassFast("Interface");
+					if (!IfaceStruct.HasType(InterfaceBaseClass))
+						break;
+
+					if (IfaceStruct.GetPackageIndex() == CurrentPackageIdx)
+						continue;
+
+					for (UEFunction Func : IfaceStruct.GetFunctions())
+					{
+						Info.Functions.push_back(Func.GetIndex());
+						BooleanOrEqual(Info.bHasParams, Func.HasMembers());
+
+						const int32 FuncPackageIndex = Func.GetPackageIndex();
+						std::unordered_set<int32> ParamDependencies = PackageManagerUtils::GetDependencies(Func, Func.GetIndex());
+						PackageManagerUtils::SetPackageDependencies(Info.PackageDependencies.ParametersDependencies, ParamDependencies, FuncPackageIndex, true);
+						PackageManagerUtils::AddEnumPackageDependencies(Info.PackageDependencies.ClassesDependencies, ParamDependencies, FuncPackageIndex, true);
+
+						if (Func.HasMembers())
+						{
+							RequirementInfo& ReqInfo = Info.PackageDependencies.ParametersDependencies[FuncPackageIndex];
+							ReqInfo.PackageIdx = FuncPackageIndex;
+							BooleanOrEqual(ReqInfo.bShouldIncludeParameters, true);
+						}
+					}
+				}
 			}
 		}
 		else if (bIsEnum)

--- a/Dumper/Generator/Private/Managers/StructManager.cpp
+++ b/Dumper/Generator/Private/Managers/StructManager.cpp
@@ -84,13 +84,12 @@ void StructManager::InitAlignmentsAndNames()
 
 		NewOrExistingInfo.Name = UniqueNameTable.FindOrAdd(CppName, !ObjAsStruct.IsA(EClassCastFlags::Function)).first;
 
-		// Interfaces inherit from UObject by default, but as a workaround to no virtual-inheritance we make them empty
 		if (ObjAsStruct.HasType(InterfaceClass))
 		{
-			NewOrExistingInfo.Alignment = 0x1;
+			NewOrExistingInfo.Alignment = sizeof(void*);
 			NewOrExistingInfo.bHasReusedTrailingPadding = false;
-			NewOrExistingInfo.bIsFinal = true;
-			NewOrExistingInfo.Size = 0x0;
+			NewOrExistingInfo.bIsFinal = false;
+			NewOrExistingInfo.Size = sizeof(void*);
 
 			continue;
 		}
@@ -198,6 +197,18 @@ void StructManager::InitSizesAndIsFinal()
 
 			if ((PropertyOffset + PropertySize) > LastMemberEnd)
 				LastMemberEnd = PropertyOffset + PropertySize;
+		}
+
+		if (ObjAsStruct.IsA(EClassCastFlags::Class))
+		{
+			for (const FImplementedInterface& Iface : ObjAsStruct.Cast<UEClass>().GetImplementedInterfaces())
+			{
+				if (Iface.bImplementedByK2 || !Iface.InterfaceClass)
+					continue;
+
+				if (Iface.PointerOffset > 0 && Iface.PointerOffset < LowestOffset)
+					LowestOffset = Iface.PointerOffset;
+			}
 		}
 
 		/* No need to check any other structs, as finding the LastMemberEnd only involves this struct */

--- a/Dumper/Generator/Private/Wrappers/StructWrapper.cpp
+++ b/Dumper/Generator/Private/Wrappers/StructWrapper.cpp
@@ -114,6 +114,40 @@ bool StructWrapper::IsInterface() const
     return bIsUnrealStruct && Struct.IsA(EClassCastFlags::Class) && Struct.HasType(InterfaceClass);
 }
 
+bool StructWrapper::IsVerseGeneratedClass() const
+{
+    if (!bIsUnrealStruct || !Struct.IsA(EClassCastFlags::Class))
+        return false;
+
+    return static_cast<uint64>(Struct.Cast<UEClass>().GetCastFlags() & EClassCastFlags::VerseVMClass) != 0;
+}
+
+std::vector<FImplementedInterface> StructWrapper::GetNativeInterfaces() const
+{
+    std::vector<FImplementedInterface> Out;
+
+    if (!bIsUnrealStruct || !Struct.IsA(EClassCastFlags::Class))
+        return Out;
+
+    if (IsVerseGeneratedClass())
+        return Out;
+
+    for (const FImplementedInterface& Iface : Struct.Cast<UEClass>().GetImplementedInterfaces())
+    {
+        if (Iface.bImplementedByK2 || !Iface.InterfaceClass)
+            continue;
+
+        Out.push_back(Iface);
+    }
+
+    return Out;
+}
+
+bool StructWrapper::HasNativeInterfaces() const
+{
+    return !GetNativeInterfaces().empty();
+}
+
 bool StructWrapper::IsExactClassUObject() const
 {
     static UEClass UObjectClass = ObjectArray::FindClassFast("Object");

--- a/Dumper/Generator/Public/Generators/CppGenerator.h
+++ b/Dumper/Generator/Public/Generators/CppGenerator.h
@@ -93,9 +93,29 @@ private:
     static std::string GenerateMembers(const StructWrapper& Struct, const MemberManager& Members, int32 SuperSize, int32 SuperLastMemberEnd, int32 SuperAlign, int32 PackageIndex = -1);
     static FunctionInfo GenerateFunctionInfo(const FunctionWrapper& Func);
 
+    struct InterfaceMILayout
+    {
+        struct Entry
+        {
+            UEClass Interface;
+            int32 PaddingBefore = 0;
+            int32 PaddingTag = 0;
+        };
+
+        bool bIsViable = false;
+        std::string FallbackReason;
+        std::vector<Entry> Entries;
+        int32 TotalMIBytes = 0;
+    };
+
+    static InterfaceMILayout ComputeInterfaceMI(const StructWrapper& Struct, int32 UnalignedSuperSize);
+    static void EnsureInterfaceVftMember(UEClass InterfaceClass);
+    static std::string GetInterfaceInheritanceString(const InterfaceMILayout& Layout);
+    static void EmitInterfaceMIStaticAsserts(const StructWrapper& Struct, const InterfaceMILayout& Layout, const std::string& UniqueName, StreamType& StructFile);
+
     // return: In-header function declarations and inline functions
-    static std::string GenerateSingleFunction(const FunctionWrapper& Func, const std::string& StructName, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile);
-    static std::string GenerateFunctions(const StructWrapper& Struct, const MemberManager& Members, const std::string& StructName, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile);
+    static std::string GenerateSingleFunction(const FunctionWrapper& Func, const std::string& StructName, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile, bool bForceImplementerDispatch = false);
+    static std::string GenerateFunctions(const StructWrapper& Struct, const MemberManager& Members, const std::string& StructName, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile, bool bEmitMIInterfaceOverride = false);
 
     static void GenerateStruct(const StructWrapper& Struct, StreamType& StructFile, StreamType& FunctionFile, StreamType& ParamFile, StreamType& AssertionFile, int32 PackageIndex = -1, const std::string& StructNameOverride = std::string());
 

--- a/Dumper/Generator/Public/Managers/PackageManager.h
+++ b/Dumper/Generator/Public/Managers/PackageManager.h
@@ -20,6 +20,7 @@ struct RequirementInfo
 	int32 PackageIdx;
 	bool bShouldIncludeStructs;
 	bool bShouldIncludeClasses;
+	bool bShouldIncludeParameters;
 };
 
 struct VisitedNodeInformation

--- a/Dumper/Generator/Public/Wrappers/StructWrapper.h
+++ b/Dumper/Generator/Public/Wrappers/StructWrapper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Unreal/ObjectArray.h"
+#include "Unreal/UnrealTypes.h"
 
 #include "Managers/CollisionManager.h"
 #include "Managers/StructManager.h"
@@ -55,6 +56,11 @@ public:
     bool IsUnion() const;
     bool IsFunction() const;
     bool IsInterface() const;
+
+    bool IsVerseGeneratedClass() const;
+
+    std::vector<FImplementedInterface> GetNativeInterfaces() const;
+    bool HasNativeInterfaces() const;
 
 	bool IsExactClassUObject() const;
 


### PR DESCRIPTION
interfaces used to be empty `final` stubs with size 0. now they have a real `void* Vft` member at offset 0 (mirrors engine's IInterface vtable ptr) and implementer classes actually inherit them via MI:

```cpp
// before
class IInterface_AssetUserData final {};
class UActorComponent : public UObject { ... };
// reinterpret_cast<IInterface_AssetUserData*>(comp)->Method()  <- you had to do this

// after
class IInterface_AssetUserData { public: void* Vft; ... };
class UActorComponent : public UObject, public IInterface_AssetUserData { ... };
// comp->HasAssetUserDataOfClass(MyClass)  <- just works now
```

each iface method gets re-emitted as a member of the implementer too, so comp->Method() looks up the UFunction directly on comp instead of going through a cast. every (impl, iface) pair also gets a static_assert(offsetof(...) == PointerOffset). if the engine ever lays things out differently the build breaks immediately instead of crashing at runtime.

bunch of supporting stuff:
- StructManager shrinks supers when engine packs an iface VFT into their trailing pad (extension of the existing pad-reuse pass)
- MIPad::Pad<N, Tag> template inserted between MI bases when engine has unreflected bytes there
- new bShouldIncludeParameters flag so implementer's _parameters.hpp picks up cross-package iface Params
- dedup re-emit against own UFunctions AND UPROPERTY names

I've tested on 6 unreal-engine games, "Tree-4.16", "Unreal PT-4.19", "One-armed Cook-4.27", "High On Life-4.27", Quarantine Zone-5.5.4", "Dead By Daylight-5.6.1"