### PR TITLE
Added two `UClass::GetFunction` overloads (#535)

### DIFF
--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -2544,6 +2544,43 @@ R"({
 })",
 			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = false
 		},
+		PredefinedFunction {
+			.CustomComment = "Gets a UFunction from this UClasses' 'Children' list",
+			.ReturnType = "class UFunction*", .NameWithParams = "GetFunction(const FName& ClassName, const FName& FuncName)", .Body =
+R"({
+	for (const UStruct* Clss = this; Clss; Clss = Clss->SuperStruct)
+	{
+		if (Clss->Name != ClassName)
+			continue;
+
+		for (UField* Field = Clss->Children; Field; Field = Field->Next)
+		{
+			if (Field->HasTypeFlag(EClassCastFlags::Function) && Field->Name == FuncName)
+				return static_cast<class UFunction*>(Field);
+		}
+	}
+
+	return nullptr;
+})",
+			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = false
+		},
+		PredefinedFunction {
+			.CustomComment = "Gets the first UFunction from the UClass inheritance hierarchy",
+			.ReturnType = "class UFunction*", .NameWithParams = "GetFunction(const FName& FuncName)", .Body =
+R"({
+	for (const UStruct* Clss = this; Clss; Clss = Clss->SuperStruct)
+	{
+		for (UField* Field = Clss->Children; Field; Field = Field->Next)
+		{
+			if (Field->HasTypeFlag(EClassCastFlags::Function) && Field->Name == FuncName)
+				return static_cast<class UFunction*>(Field);
+		}
+	}
+
+	return nullptr;
+})",
+			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = false
+		},
 	};
 
 


### PR DESCRIPTION
Added two `UClass::GetFunction` overloads: one to search for a specific class and function by `FName`, and another to find the first function in the class inheritance hierarchy by function `FName`.

I've tested the `UFunction* GetFunction(const FName& FuncName) const;` function in my The Outlast Trials hack, where I can't dump BP classes in specific missions to get function definitions.
```cpp
bool CoreUtilsEx::GetClue(AActor* actor, FClueData* outClue)
{
	if (!actor || !actor->Class || !outClue) return false;

	struct GetClueParams
	{
		FClueData ReturnValue;
	};

	const auto function = actor->Class->GetFunction(GetGetClueName());
	if (!function) return false;

	GetClueParams Parms{};

	auto flags = function->FunctionFlags;
	function->FunctionFlags |= 0x400;
	actor->ProcessEvent(function, &Parms);
	function->FunctionFlags = flags;

	*outClue = Parms.ReturnValue;

	return true;
}
```

Haven't tested the function that accepts ClassName as FName, but it's so straight forward that I don't see how it could be wrong.