### PR TITLE
Issue #544 - Fix UE v5.8 crash when resolving FFieldClass names

### DIFF
--- a/Dumper/Engine/Private/OffsetFinder/OffsetFinder.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/OffsetFinder.cpp
@@ -4,6 +4,7 @@
 #include "OffsetFinder/OffsetFinder.h"
 #include "Unreal/ObjectArray.h"
 
+#include "Settings.h"
 #include "Platform.h"
 
 /* UObject */
@@ -660,6 +661,61 @@ int32_t OffsetFinder::FindFieldClassCastFlagsOffset()
 	const int32_t Offset = FindOffset(Infos, sizeof(void*), 0x30);
 
 	return Offset != OffsetNotFound ? Offset : 0x10;
+}
+
+void OffsetFinder::InitFFieldClassLayout()
+{
+	if (!Settings::Internal::bUseFProperty)
+		return;
+
+	const UEFField GuidChild = ObjectArray::FindStructFast("Guid").GetChildProperties();
+	const UEFField ColorChild = ObjectArray::FindStructFast("Color").GetChildProperties();
+
+	auto IsLikelyProcessPointer = [](const uint64 Value) -> bool
+	{
+		if (Value < 0x10000 || (Value & 0x7) != 0)
+			return false;
+
+		if ((Value >> 48) == 0)
+			return false;
+
+		return !Platform::IsBadReadPtr(reinterpret_cast<const void*>(Value));
+	};
+
+	bool bGuidIsExtended = false;
+	bool bColorIsExtended = false;
+
+	if (GuidChild)
+	{
+		if (const void* const GuidClass = GuidChild.GetClass().GetAddress())
+			bGuidIsExtended = IsLikelyProcessPointer(*reinterpret_cast<const uint64*>(GuidClass));
+	}
+
+	if (ColorChild)
+	{
+		if (const void* const ColorClass = ColorChild.GetClass().GetAddress())
+			bColorIsExtended = IsLikelyProcessPointer(*reinterpret_cast<const uint64*>(ColorClass));
+	}
+
+	/* UE5.8+ moves CastFlags to 0x20. Either signal is enough; do not require both Guid and Color. */
+	Settings::Internal::bUseExtendedFFieldClassLayout = bGuidIsExtended
+		|| bColorIsExtended
+		|| Off::FFieldClass::CastFlags >= static_cast<int32>(0x20);
+
+	if (!GuidChild && !ColorChild && !Settings::Internal::bUseExtendedFFieldClassLayout)
+	{
+		std::cerr << std::format("\nDumper-7: bUseExtendedFFieldClassLayout = false (could not find Guid/Color properties)\n\n");
+		return;
+	}
+
+	if (Settings::Internal::bUseExtendedFFieldClassLayout)
+	{
+		/* CastFlags and SuperClass both defaulted to 0x20; on extended layouts SuperClass follows CastFlags. */
+		Off::FFieldClass::SuperClass = Off::FFieldClass::CastFlags + static_cast<int32>(sizeof(uint64));
+		std::cerr << std::format("Off::FFieldClass::SuperClass: 0x{:X}\n", Off::FFieldClass::SuperClass);
+	}
+
+	std::cerr << std::format("\nDumper-7: bUseExtendedFFieldClassLayout = {}\n\n", Settings::Internal::bUseExtendedFFieldClassLayout);
 }
 
 /* UEnum */

--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -346,7 +346,9 @@ void Off::Init()
 			std::cerr << std::format("Off::FField::EditorOnlyMetadata: 0x{:X}\n", Off::FField::EditorOnlyMetadata);
 
 		Off::FFieldClass::CastFlags = OffsetFinder::FindFieldClassCastFlagsOffset();
-		std::cerr << std::format("Off::FFieldClass::CastFlags: 0x{:X}\n\n", Off::FFieldClass::CastFlags);
+		std::cerr << std::format("Off::FFieldClass::CastFlags: 0x{:X}\n", Off::FFieldClass::CastFlags);
+
+		OffsetFinder::InitFFieldClassLayout();
 	}
 
 	Off::UStruct::StructBaseChain = OffsetFinder::FindStructBaseChainOffset();

--- a/Dumper/Engine/Private/Unreal/UnrealObjects.cpp
+++ b/Dumper/Engine/Private/Unreal/UnrealObjects.cpp
@@ -3,7 +3,25 @@
 #include "Unreal/UnrealObjects.h"
 #include "Unreal/ObjectArray.h"
 #include "OffsetFinder/Offsets.h"
+#include "Settings.h"
+#include "Platform.h"
 
+namespace
+{
+bool IsFFieldClassDescriptorPointer(const uint8* Class)
+{
+	if (!Class) return false;
+	const uint64 Value = *reinterpret_cast<const uint64*>(Class);
+	if (Value < 0x10000 || (Value & 0x7) != 0) return false;
+	if ((Value >> 48) == 0) return false;
+	return !Platform::IsBadReadPtr(reinterpret_cast<const void*>(Value));
+}
+bool ShouldUseExtendedFFieldClassName(const uint8* Class)
+{
+	return Settings::Internal::bUseExtendedFFieldClassLayout
+		|| IsFFieldClassDescriptorPointer(Class);
+}
+} // namespace
 
 void* UEFFieldClass::GetAddress()
 {
@@ -37,6 +55,9 @@ UEFFieldClass UEFFieldClass::GetSuper() const
 
 FName UEFFieldClass::GetFName() const
 {
+	if (ShouldUseExtendedFFieldClassName(Class))
+		return FName(nullptr);
+
 	return FName(Class + Off::FFieldClass::Name); //Not the real FName, but a wrapper which holds the address of a FName
 }
 
@@ -47,12 +68,24 @@ bool UEFFieldClass::IsType(EClassCastFlags Flags) const
 
 std::string UEFFieldClass::GetName() const
 {
-	return Class ? GetFName().ToString() : "None";
+	if (!Class)
+		return "None";
+
+	if (ShouldUseExtendedFFieldClassName(Class))
+		return GetPrimaryFFieldClassNameFromCastFlags(GetCastFlags());
+
+	return GetFName().ToString();
 }
 
 std::string UEFFieldClass::GetValidName() const
 {
-	return Class ? GetFName().ToValidString() : "None";
+	if (!Class)
+		return "None";
+
+	if (ShouldUseExtendedFFieldClassName(Class))
+		return GetName();
+
+	return GetFName().ToValidString();
 }
 
 std::string UEFFieldClass::GetCppName() const

--- a/Dumper/Engine/Public/OffsetFinder/OffsetFinder.h
+++ b/Dumper/Engine/Public/OffsetFinder/OffsetFinder.h
@@ -98,6 +98,7 @@ namespace OffsetFinder
 
 	/* FFieldClass */
 	int32_t FindFieldClassCastFlagsOffset();
+	void InitFFieldClassLayout();
 
 	/* UEnum */
 	int32_t FindEnumNamesOffset();

--- a/Dumper/Engine/Public/OffsetFinder/Offsets.h
+++ b/Dumper/Engine/Public/OffsetFinder/Offsets.h
@@ -143,11 +143,12 @@ namespace Off
 	{
 		// Fixed for CasePreserving FNames by OffsetFinder::FixupHardcodedOffsets();
 		// Fixed for OutlineNumber FNames by OffsetFinder::FixFNameSize();
+		// UE5.8+ extended layout: Descriptor at 0x0 (see InitFFieldClassLayout). Legacy layout: FName Name at 0x0.
 		inline int32 Name = 0x00;
 		inline int32 Id = 0x08;
-		inline int32 CastFlags = 0x10; // 0x18 on UE5.7
+		inline int32 CastFlags = 0x10; // 0x18 on UE5.7, 0x20 on UE5.8+
 		inline int32 ClassFlags = 0x18;
-		inline int32 SuperClass = 0x20;
+		inline int32 SuperClass = 0x20; // 0x28 on UE5.8+ extended layout
 	}
 
 	namespace FName

--- a/Dumper/Engine/Public/Unreal/Enums.h
+++ b/Dumper/Engine/Public/Unreal/Enums.h
@@ -597,3 +597,64 @@ static std::string StringifyClassCastFlags(EClassCastFlags CastFlags)
 
 	return RetFlags.size() > 2 ? RetFlags.erase(RetFlags.size() - 2) : RetFlags;
 }
+
+/* Returns the most specific cast-flag name for an FFieldClass (e.g. "IntProperty", not "Field, Property, ..."). */
+inline std::string GetPrimaryFFieldClassNameFromCastFlags(EClassCastFlags CastFlags)
+{
+	static constexpr std::pair<EClassCastFlags, const char*> PropertyTypeNames[] =
+	{
+		{ EClassCastFlags::VCellProperty, "VCellProperty" },
+		{ EClassCastFlags::AnsiStrProperty, "AnsiStrProperty" },
+		{ EClassCastFlags::Utf8StrProperty, "Utf8StrProperty" },
+		{ EClassCastFlags::VRestValueProperty, "VRestValueProperty" },
+		{ EClassCastFlags::VValueProperty, "VValueProperty" },
+		{ EClassCastFlags::VerseVMClass, "VerseVMClass" },
+		{ EClassCastFlags::OptionalProperty, "OptionalProperty" },
+		{ EClassCastFlags::LargeWorldCoordinatesRealProperty, "LargeWorldCoordinatesRealProperty" },
+		{ EClassCastFlags::MulticastSparseDelegateProperty, "MulticastSparseDelegateProperty" },
+		{ EClassCastFlags::MulticastInlineDelegateProperty, "MulticastInlineDelegateProperty" },
+		{ EClassCastFlags::SparseDelegateFunction, "SparseDelegateFunction" },
+		{ EClassCastFlags::EnumProperty, "EnumProperty" },
+		{ EClassCastFlags::SetProperty, "SetProperty" },
+		{ EClassCastFlags::MapProperty, "MapProperty" },
+		{ EClassCastFlags::FieldPathProperty, "FieldPathProperty" },
+		{ EClassCastFlags::MulticastDelegateProperty, "MulticastDelegateProperty" },
+		{ EClassCastFlags::DelegateProperty, "DelegateProperty" },
+		{ EClassCastFlags::ArrayProperty, "ArrayProperty" },
+		{ EClassCastFlags::StructProperty, "StructProperty" },
+		{ EClassCastFlags::SoftClassProperty, "SoftClassProperty" },
+		{ EClassCastFlags::DoubleProperty, "DoubleProperty" },
+		{ EClassCastFlags::Int16Property, "Int16Property" },
+		{ EClassCastFlags::TextProperty, "TextProperty" },
+		{ EClassCastFlags::SoftObjectProperty, "SoftObjectProperty" },
+		{ EClassCastFlags::LazyObjectProperty, "LazyObjectProperty" },
+		{ EClassCastFlags::WeakObjectProperty, "WeakObjectProperty" },
+		{ EClassCastFlags::ObjectProperty, "ObjectProperty" },
+		{ EClassCastFlags::BoolProperty, "BoolProperty" },
+		{ EClassCastFlags::UInt16Property, "UInt16Property" },
+		{ EClassCastFlags::UInt32Property, "UInt32Property" },
+		{ EClassCastFlags::UInt64Property, "UInt64Property" },
+		{ EClassCastFlags::ClassProperty, "ClassProperty" },
+		{ EClassCastFlags::InterfaceProperty, "InterfaceProperty" },
+		{ EClassCastFlags::FloatProperty, "FloatProperty" },
+		{ EClassCastFlags::IntProperty, "IntProperty" },
+		{ EClassCastFlags::Int64Property, "Int64Property" },
+		{ EClassCastFlags::ByteProperty, "ByteProperty" },
+		{ EClassCastFlags::Int8Property, "Int8Property" },
+		{ EClassCastFlags::NameProperty, "NameProperty" },
+		{ EClassCastFlags::StrProperty, "StrProperty" },
+		{ EClassCastFlags::ObjectPropertyBase, "ObjectPropertyBase" },
+		{ EClassCastFlags::NumericProperty, "NumericProperty" },
+		{ EClassCastFlags::Property, "Property" },
+		{ EClassCastFlags::Function, "Function" },
+		{ EClassCastFlags::Field, "Field" },
+	};
+
+	for (const auto& [Flag, Name] : PropertyTypeNames)
+	{
+		if (CastFlags & Flag)
+			return Name;
+	}
+
+	return "Field";
+}

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -2157,7 +2157,10 @@ void CppGenerator::InitPredefinedMembers()
 		{
 			PredefinedMember {
 				.Comment = "NOT AUTO-GENERATED PROPERTY",
-				.Type = "FName", .Name = "Name", .Offset = Off::FFieldClass::Name, .Size = Off::InSDK::Name::FNameSize, .ArrayDim = 0x1, .Alignment = alignof(int32),
+				.Type = Settings::Internal::bUseExtendedFFieldClassLayout ? "void*" : "FName",
+				.Name = Settings::Internal::bUseExtendedFFieldClassLayout ? "Descriptor" : "Name",
+				.Offset = Off::FFieldClass::Name, .Size = Settings::Internal::bUseExtendedFFieldClassLayout ? static_cast<int32>(sizeof(void*)) : Off::InSDK::Name::FNameSize,
+				.ArrayDim = 0x1, .Alignment = alignof(void*),
 				.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
 			},
 			PredefinedMember {
@@ -2181,6 +2184,21 @@ void CppGenerator::InitPredefinedMembers()
 				.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
 			},
 		};
+
+		if (Settings::Internal::bUseExtendedFFieldClassLayout)
+		{
+			const int32 PadOffset = Off::FFieldClass::Id + static_cast<int32>(sizeof(uint64));
+			const int32 PadSize = Off::FFieldClass::ClassFlags - PadOffset;
+
+			if (PadSize > 0)
+			{
+				FFieldClass.Properties.push_back(PredefinedMember{
+					.Comment = "NOT AUTO-GENERATED PROPERTY",
+					.Type = std::format("uint8[{}]", PadSize), .Name = "Pad", .Offset = PadOffset, .Size = PadSize, .ArrayDim = 0x1, .Alignment = 0x1,
+					.bIsStatic = false, .bIsZeroSizeMember = false, .bIsBitField = false, .BitIndex = 0xFF
+				});
+			}
+		}
 
 
 		const int32 FFieldVariantSize = Settings::Internal::bUseMaskForFieldOwner ? 0x8 : 0x10;

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -172,6 +172,9 @@ R"(
 
 		/* Whether this game uses uint8 for UEProperty::ArrayDim, instead of int32 */
 		inline bool bUseUint8ArrayDim = false;
+
+		/* UE5.8+ FFieldClass stores a descriptor pointer at +0x0 instead of an FName. Names are derived from CastFlags. */
+		inline bool bUseExtendedFFieldClassLayout = false;
 	}
 
 	extern void InitWeakObjectPtrSettings();


### PR DESCRIPTION
On UE 5.8, FFieldClass+0x0 is a descriptor pointer, not FName, which caused crash in AppendString during DumpObjectsWithProperties

Add runtime layout detection, get names from CastFlags on 5.8 Fix SuperClass offset (CastFlags+8) and update generated FFieldClass SDK Legacy path (x<v5.8) unchanged.