### PR TITLE
Marvel Rivals fixes 

### DIFF
--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -1129,8 +1129,8 @@ std::string CppGenerator::GetMemberTypeStringWithoutConst(UEProperty Member, int
 		{
 			EnumWrapper WrappedEnum = EnumWrapper(Enum);
 
-			//if (WrappedEnum.GetUnderlyingTypeSize() != Member.GetSize())
-			//	return GetEnumForcedSizeType(WrappedEnum, Member.GetSize());
+			if (WrappedEnum.GetUnderlyingTypeSize() != Member.GetSize())
+				return GetEnumForcedSizeType(WrappedEnum, Member.GetSize());
 
 			return GetEnumPrefixedName(WrappedEnum);
 		}

--- a/Dumper/Generator/Private/Managers/PackageManager.cpp
+++ b/Dumper/Generator/Private/Managers/PackageManager.cpp
@@ -512,8 +512,8 @@ void PackageManager::HandleCycles()
 			/* Which of the two cyclic packages requires less structs from the other package. */
 			const bool bCurrentHasMoreDependencies = NumStructsRequiredByCurrent > NumStructsRequiredByPrevious;
 
-			const int32 PackageIndexWithLeastDependencies = bCurrentHasMoreDependencies && bIsStruct ? PreviousPackageIndex : CurrentPackageIndex;
-			const int32 PackageIndexToMarkCyclicWith = bCurrentHasMoreDependencies && bIsStruct ? CurrentPackageIndex : PreviousPackageIndex;
+			const int32 PackageIndexWithLeastDependencies = bCurrentHasMoreDependencies ? PreviousPackageIndex : CurrentPackageIndex;
+			const int32 PackageIndexToMarkCyclicWith = bCurrentHasMoreDependencies ? CurrentPackageIndex : PreviousPackageIndex;
 
 
 			/* Add package to HandledPackages */
@@ -527,7 +527,7 @@ void PackageManager::HandleCycles()
 
 			const DependencyManager& LoserStructsOrClasses = (PackageIndexWithLeastDependencies == PreviousPackageIndex) ? PreviousStructsOrClasses : CurrentStructsOrClasses;
 
-			PreviousStructsOrClasses.VisitAllNodesWithCallback(SetCycleCallback);
+			LoserStructsOrClasses.VisitAllNodesWithCallback(SetCycleCallback);
 		}
 		else /* Just mark structs|classes from the previous package as cyclic */
 		{
@@ -559,7 +559,14 @@ void PackageManager::HandleCycles()
 			continue;
 		}
 
-		const RequirementInfo& CurrentRequirements = CurrentPackageInfo.GetPackageDependencies().ClassesDependencies.at(Cycle.CurrentPackage);
+		auto DepIt = CurrentPackageInfo.GetPackageDependencies().ClassesDependencies.find(Cycle.PreviousPacakge);
+
+		if (DepIt == CurrentPackageInfo.GetPackageDependencies().ClassesDependencies.end())
+		{
+			continue;
+		}
+
+		const RequirementInfo& CurrentRequirements = DepIt->second;
 
 		/* Mark classes as 'do not include' when this package is cyclic but can still require _structs.hpp */
 		if (CurrentRequirements.bShouldIncludeStructs)


### PR DESCRIPTION
This solves #547. Tested also,

and test it on the other 3 games to make sure there is no regression. 

Also, it fixes some offsets becoming Null (in Marvel) and AV crashes.