### PR TITLE
Generator.cpp->DumpEditorOnlyMetadata() remove double Struct.GetProperties() call

### DIFF
--- a/Dumper/Generator/Private/Generators/Generator.cpp
+++ b/Dumper/Generator/Private/Generators/Generator.cpp
@@ -165,14 +165,12 @@ void DumpEditorOnlyMetadata(const fs::path& DumperFolder)
 
 		UEStruct Struct = Obj.Cast<UEStruct>();
 
-		auto ChildProperties = Struct.GetProperties();
-
-		if (ChildProperties.empty())
+		std::vector<UEProperty> ChildProperties = Struct.GetProperties();
+		if (ChildProperties.empty()) // Avoids allocating string for GetCppName() and prevents json from auto-creating empty objects for property-less structs
 			continue;
 
 		auto& StructMembers = MetadataJson[Struct.GetCppName()];
-
-		for (UEProperty Prop : Struct.GetProperties())
+		for (UEProperty Prop : ChildProperties)
 		{
 			auto& Entries = StructMembers[Prop.GetValidName()];
 


### PR DESCRIPTION
✅ Successfully generated SDK for 4.22, 4.27 & 5.4 titles.
✅ https://github.com/Cranch-fur/UETools-GUI compiles and works w/o crashes.

[Generator.cpp]
— Struct.GetProperties() is no longer called twice.

— auto ChildProperties -> std::vector<UEProperty> ChildProperties for better readability as it's not an complex type.

— Added comment/explanation to if (ChildProperties.empty()) & why auto& StructMembers = MetadataJson[Struct.GetCppName()]; only comes after it and not before.