### PR TITLE
Generator.cpp->SetupDumperFolder() allow unlimited amount of sortable backups

### DIFF
--- a/Dumper/Generator/Private/Generators/Generator.cpp
+++ b/Dumper/Generator/Private/Generators/Generator.cpp
@@ -88,8 +88,15 @@ bool Generator::SetupDumperFolder()
 		{
 			fs::path OldFolder = DumperFolder;
 
-			std::time_t Now = std::time(nullptr);
-			OldFolder += ("_" + std::to_string(Now));
+			if (Settings::Generator::bCreateUniqueBackups)
+			{
+				std::time_t Now = std::time(nullptr);
+				OldFolder += ("_" + std::to_string(Now));
+			}
+			else
+			{
+				OldFolder += "_OLD";
+			}
 
 			std::cerr << "Folder already exists. Backing up to: " << OldFolder.generic_string() << "\n";
 

--- a/Dumper/Generator/Private/Generators/Generator.cpp
+++ b/Dumper/Generator/Private/Generators/Generator.cpp
@@ -81,18 +81,20 @@ bool Generator::SetupDumperFolder()
 	try
 	{
 		std::string FolderName = (Settings::Generator::GameVersion + '-' + Settings::Generator::GameName);
-
 		FileNameHelper::MakeValidFileName(FolderName);
 
 		DumperFolder = fs::path(Settings::Generator::SDKGenerationPath) / FolderName;
-
 		if (fs::exists(DumperFolder))
 		{
-			fs::path Old = DumperFolder.generic_string() + "_OLD";
+			fs::path OldFolder = DumperFolder;
 
-			fs::remove_all(Old);
+			std::time_t Now = std::time(nullptr);
+			OldFolder += ("_" + std::to_string(Now));
 
-			fs::rename(DumperFolder, Old);
+			std::cerr << "Folder already exists. Backing up to: " << OldFolder.generic_string() << "\n";
+
+			fs::remove_all(OldFolder);
+			fs::rename(DumperFolder, OldFolder);
 		}
 
 		fs::create_directories(DumperFolder);

--- a/Dumper/Settings.h
+++ b/Dumper/Settings.h
@@ -43,6 +43,9 @@ namespace Settings
 		inline std::string GameVersion = "";
 
 		inline std::string SDKGenerationPath = "C:/Dumper-7";
+
+		/* Whether to use a timestamp suffix for backup folders instead of "_OLD", allowing unlimited backups */
+		inline bool bCreateUniqueBackups = false;
 	}
 
 	namespace CppGenerator


### PR DESCRIPTION
✅ Successfully generated SDK for 4.22, 4.27 & 5.4 titles.
✅ https://github.com/Cranch-fur/UETools-GUI compiles and works w/o crashes.

— fs::path Old -> fs::path OldFolder for better code readability.

— Replace const "_OLD" suffix with std::time(nullptr); so Dumper-7 can make an unlimited amount of sortable backups.

— Added std::cerr output reporting that folder already exists and backup was made.