### PR TITLE
StructManager.cpp->InitSizesAndIsFinal() Avoid expensive std::unordered_map lookup for reference of an object we already have

### DIFF
--- a/Dumper/Generator/Private/Managers/StructManager.cpp
+++ b/Dumper/Generator/Private/Managers/StructManager.cpp
@@ -166,23 +166,21 @@ void StructManager::InitSizesAndIsFinal()
 	const UEClass InterfaceClass = ObjectArray::FindClassFast("Interface");
 
 	// Reuse cached struct list from InitAlignmentsAndNames
-	for (const auto& [Index, Info] : StructInfoOverrides)
+	for (auto& [Index, Info] : StructInfoOverrides)
 	{
 		UEStruct ObjAsStruct = ObjectArray::GetByIndex<UEStruct>(Index);
 		
 		if (ObjAsStruct.HasType(InterfaceClass))
 			continue;
 
-		StructInfo& NewOrExistingInfo = StructInfoOverrides[Index];
-
 		// Initialize struct-size if it wasn't set already
-		if (NewOrExistingInfo.Size > ObjAsStruct.GetStructSize())
-			NewOrExistingInfo.Size = ObjAsStruct.GetStructSize();
+		if (Info.Size > ObjAsStruct.GetStructSize())
+			Info.Size = ObjAsStruct.GetStructSize();
 
 		UEStruct Super = ObjAsStruct.GetSuper();
 
-		if (NewOrExistingInfo.Size == 0x0 && Super != nullptr)
-			NewOrExistingInfo.Size = Super.GetStructSize();
+		if (Info.Size == 0x0 && Super != nullptr)
+			Info.Size = Super.GetStructSize();
 
 		int32 LastMemberEnd = 0x0;
 		int32 LowestOffset = INT_MAX;
@@ -201,7 +199,7 @@ void StructManager::InitSizesAndIsFinal()
 		}
 
 		/* No need to check any other structs, as finding the LastMemberEnd only involves this struct */
-		NewOrExistingInfo.LastMemberEnd = LastMemberEnd;
+		Info.LastMemberEnd = LastMemberEnd;
 
 		if (!Super || ObjAsStruct.IsA(EClassCastFlags::Function))
 			continue;


### PR DESCRIPTION
✅ Successfully generated SDK for 4.22, 4.27 & 5.4 titles.
✅ https://github.com/Cranch-fur/UETools-GUI compiles and works w/o crashes.

[StructManager.cpp]
— InitSizesAndIsFinal() no longer declares StructInfo& NewOrExistingInfo which was the same reference we already had from for() loop.

— InitSizesAndIsFinal() for() loop is no longer const as we might need to change its members properties.