### PR TITLE
fix: support alternate UE 5.7 layouts

### DIFF
--- a/Dumper/Engine/Private/OffsetFinder/OffsetFinder.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/OffsetFinder.cpp
@@ -662,6 +662,32 @@ int32_t OffsetFinder::FindFieldClassCastFlagsOffset()
 	return Offset != OffsetNotFound ? Offset : 0x10;
 }
 
+void OffsetFinder::FixupFieldClassOffsets()
+{
+	/*
+	* UE5.7 uses this FFieldClass layout with an 8-byte FName:
+	*
+	* struct FFieldClass
+	* {
+	*     FName Name;                    // 0x00
+	*     EClassFlags ClassFlags;        // 0x08
+	*     uint32 Padding;                // 0x0C
+	*     EFieldClassID Id;              // 0x10
+	*     EClassCastFlags CastFlags;     // 0x18
+	*     FFieldClass* SuperClass;       // 0x20
+	* };
+	*/
+	constexpr int32 CastFlagsOffsetFromClassFlags = static_cast<int32>(
+		Align(sizeof(EClassFlags), alignof(EFieldClassID)) + sizeof(EFieldClassID));
+
+	if (Off::FFieldClass::CastFlags == (Off::FFieldClass::Id + CastFlagsOffsetFromClassFlags)
+		&& Off::FFieldClass::SuperClass == (Off::FFieldClass::CastFlags + sizeof(EClassCastFlags)))
+	{
+		Off::FFieldClass::ClassFlags = Off::FFieldClass::Id;
+		Off::FFieldClass::Id = Off::FFieldClass::CastFlags - sizeof(EFieldClassID);
+	}
+}
+
 /* UEnum */
 int32_t OffsetFinder::FindEnumNamesOffset()
 {

--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -348,8 +348,11 @@ void Off::Init()
 		Off::FFieldClass::CastFlags = OffsetFinder::FindFieldClassCastFlagsOffset();
 
 		/* UE5.7 moved ClassFlags before Id. */
-		constexpr int32 FFieldClassReorderedCastFlagsOffsetFromClassFlags = static_cast<int32>(Align(sizeof(EClassFlags), alignof(EFieldClassID)) + sizeof(EFieldClassID));
-		if (Off::FFieldClass::CastFlags == (Off::FFieldClass::Id + FFieldClassReorderedCastFlagsOffsetFromClassFlags) && Off::FFieldClass::SuperClass == (Off::FFieldClass::CastFlags + sizeof(EClassCastFlags)))
+		constexpr int32 CastFlagsOffsetFromClassFlags = static_cast<int32>(
+			Align(sizeof(EClassFlags), alignof(EFieldClassID)) + sizeof(EFieldClassID));
+
+		if (Off::FFieldClass::CastFlags == (Off::FFieldClass::Id + CastFlagsOffsetFromClassFlags)
+			&& Off::FFieldClass::SuperClass == (Off::FFieldClass::CastFlags + sizeof(EClassCastFlags)))
 		{
 			Off::FFieldClass::ClassFlags = Off::FFieldClass::Id;
 			Off::FFieldClass::Id = Off::FFieldClass::CastFlags - sizeof(EFieldClassID);

--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -346,17 +346,7 @@ void Off::Init()
 			std::cerr << std::format("Off::FField::EditorOnlyMetadata: 0x{:X}\n", Off::FField::EditorOnlyMetadata);
 
 		Off::FFieldClass::CastFlags = OffsetFinder::FindFieldClassCastFlagsOffset();
-
-		/* UE5.7 moved ClassFlags before Id. */
-		constexpr int32 CastFlagsOffsetFromClassFlags = static_cast<int32>(
-			Align(sizeof(EClassFlags), alignof(EFieldClassID)) + sizeof(EFieldClassID));
-
-		if (Off::FFieldClass::CastFlags == (Off::FFieldClass::Id + CastFlagsOffsetFromClassFlags)
-			&& Off::FFieldClass::SuperClass == (Off::FFieldClass::CastFlags + sizeof(EClassCastFlags)))
-		{
-			Off::FFieldClass::ClassFlags = Off::FFieldClass::Id;
-			Off::FFieldClass::Id = Off::FFieldClass::CastFlags - sizeof(EFieldClassID);
-		}
+		OffsetFinder::FixupFieldClassOffsets();
 
 		std::cerr << std::format("Off::FFieldClass::CastFlags: 0x{:X}\n\n", Off::FFieldClass::CastFlags);
 	}

--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -346,6 +346,14 @@ void Off::Init()
 			std::cerr << std::format("Off::FField::EditorOnlyMetadata: 0x{:X}\n", Off::FField::EditorOnlyMetadata);
 
 		Off::FFieldClass::CastFlags = OffsetFinder::FindFieldClassCastFlagsOffset();
+
+		/* UE5.7 moved ClassFlags before Id. */
+		if (Off::FFieldClass::CastFlags == (Off::FFieldClass::Id + 0x10) && Off::FFieldClass::SuperClass == (Off::FFieldClass::CastFlags + 0x08))
+		{
+			Off::FFieldClass::ClassFlags = Off::FFieldClass::Id;
+			Off::FFieldClass::Id = Off::FFieldClass::CastFlags - 0x08;
+		}
+
 		std::cerr << std::format("Off::FFieldClass::CastFlags: 0x{:X}\n\n", Off::FFieldClass::CastFlags);
 	}
 

--- a/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
+++ b/Dumper/Engine/Private/OffsetFinder/Offsets.cpp
@@ -348,10 +348,11 @@ void Off::Init()
 		Off::FFieldClass::CastFlags = OffsetFinder::FindFieldClassCastFlagsOffset();
 
 		/* UE5.7 moved ClassFlags before Id. */
-		if (Off::FFieldClass::CastFlags == (Off::FFieldClass::Id + 0x10) && Off::FFieldClass::SuperClass == (Off::FFieldClass::CastFlags + 0x08))
+		constexpr int32 FFieldClassReorderedCastFlagsOffsetFromClassFlags = static_cast<int32>(Align(sizeof(EClassFlags), alignof(EFieldClassID)) + sizeof(EFieldClassID));
+		if (Off::FFieldClass::CastFlags == (Off::FFieldClass::Id + FFieldClassReorderedCastFlagsOffsetFromClassFlags) && Off::FFieldClass::SuperClass == (Off::FFieldClass::CastFlags + sizeof(EClassCastFlags)))
 		{
 			Off::FFieldClass::ClassFlags = Off::FFieldClass::Id;
-			Off::FFieldClass::Id = Off::FFieldClass::CastFlags - 0x08;
+			Off::FFieldClass::Id = Off::FFieldClass::CastFlags - sizeof(EFieldClassID);
 		}
 
 		std::cerr << std::format("Off::FFieldClass::CastFlags: 0x{:X}\n\n", Off::FFieldClass::CastFlags);

--- a/Dumper/Engine/Private/Unreal/ObjectArray.cpp
+++ b/Dumper/Engine/Private/Unreal/ObjectArray.cpp
@@ -67,11 +67,11 @@ constexpr inline std::array FChunkedFixedUObjectArrayLayouts =
 	},
 	FChunkedFixedUObjectArrayLayout // UE5.7 variant observed in Mistfall Hunter
 	{
-		.ObjectsOffset = 0x20,
-		.MaxElementsOffset = 0x30,
-		.NumElementsOffset = 0x34,
-		.MaxChunksOffset = 0x14,
-		.NumChunksOffset = 0x18,
+		.ObjectsOffset = 0x0C,
+		.MaxElementsOffset = 0x1C,
+		.NumElementsOffset = 0x20,
+		.MaxChunksOffset = 0x00,
+		.NumChunksOffset = 0x04,
 	}
 };
 

--- a/Dumper/Engine/Private/Unreal/ObjectArray.cpp
+++ b/Dumper/Engine/Private/Unreal/ObjectArray.cpp
@@ -67,11 +67,11 @@ constexpr inline std::array FChunkedFixedUObjectArrayLayouts =
 	},
 	FChunkedFixedUObjectArrayLayout // UE5.7 variant observed in Mistfall Hunter
 	{
-		.ObjectsOffset = 0x0C,
-		.MaxElementsOffset = 0x1C,
-		.NumElementsOffset = 0x20,
-		.MaxChunksOffset = 0x00,
-		.NumChunksOffset = 0x04,
+		.ObjectsOffset = 0x10,
+		.MaxElementsOffset = 0x20,
+		.NumElementsOffset = 0x24,
+		.MaxChunksOffset = 0x04,
+		.NumChunksOffset = 0x08,
 	}
 };
 

--- a/Dumper/Engine/Private/Unreal/ObjectArray.cpp
+++ b/Dumper/Engine/Private/Unreal/ObjectArray.cpp
@@ -64,6 +64,14 @@ constexpr inline std::array FChunkedFixedUObjectArrayLayouts =
 		.NumElementsOffset = 0x14,
 		.MaxChunksOffset = 0x10,
 		.NumChunksOffset = 0x04,
+	},
+	FChunkedFixedUObjectArrayLayout // UE5.7 variant observed in Mistfall Hunter
+	{
+		.ObjectsOffset = 0x20,
+		.MaxElementsOffset = 0x30,
+		.NumElementsOffset = 0x34,
+		.MaxChunksOffset = 0x14,
+		.NumChunksOffset = 0x18,
 	}
 };
 

--- a/Dumper/Engine/Public/OffsetFinder/OffsetFinder.h
+++ b/Dumper/Engine/Public/OffsetFinder/OffsetFinder.h
@@ -98,6 +98,7 @@ namespace OffsetFinder
 
 	/* FFieldClass */
 	int32_t FindFieldClassCastFlagsOffset();
+	void FixupFieldClassOffsets();
 
 	/* UEnum */
 	int32_t FindEnumNamesOffset();

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -3872,9 +3872,6 @@ R"({
 
 #undef max
 		const auto& ObjectsArrayLayout = Off::FUObjectArray::ChunkedFixedLayout;
-		// Preserve 4-byte-relative pointer offsets in generated layouts.
-		const bool bRequiresPacking = (ObjectsArrayLayout.ObjectsOffset % alignof(void*)) != 0;
-		const int32 ObjectArrayAlignment = bRequiresPacking ? alignof(int32) : alignof(void*);
 		const int32 ObjectArraySize = std::max({
 			ObjectsArrayLayout.ObjectsOffset + sizeof(void*),
 			ObjectsArrayLayout.MaxElementsOffset + sizeof(void*),
@@ -3886,7 +3883,7 @@ R"({
 
 		// Start class 'TUObjectArray'
 		PredefinedStruct TUObjectArray = PredefinedStruct{
-			.UniqueName = "TUObjectArray", .Size = ObjectArraySize, .Alignment = ObjectArrayAlignment, .bUseExplictAlignment = false, .bIsFinal = true, .bIsClass = true, .bIsUnion = false, .Super = nullptr
+			.UniqueName = "TUObjectArray", .Size = ObjectArraySize, .Alignment = alignof(void*), .bUseExplictAlignment = false, .bIsFinal = true, .bIsClass = true, .bIsUnion = false, .Super = nullptr
 		};
 
 		TUObjectArray.Properties =
@@ -3969,14 +3966,7 @@ R"({
 		};
 
 		SortMembers(TUObjectArray.Properties);
-
-		if (bRequiresPacking)
-			BasicHpp << std::format("#pragma pack(push, 0x{:X})\n", ObjectArrayAlignment);
-
 		GenerateStruct(&TUObjectArray, BasicHpp, BasicCpp, BasicHpp, AssertionsFile);
-
-		if (bRequiresPacking)
-			BasicHpp << "#pragma pack(pop)\n";
 	}
 	// End class 'TUObjectArray'
 

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -3872,6 +3872,9 @@ R"({
 
 #undef max
 		const auto& ObjectsArrayLayout = Off::FUObjectArray::ChunkedFixedLayout;
+		// Preserve 4-byte-relative pointer offsets in generated layouts.
+		const bool bRequiresPacking = (ObjectsArrayLayout.ObjectsOffset % alignof(void*)) != 0;
+		const int32 ObjectArrayAlignment = bRequiresPacking ? alignof(int32) : alignof(void*);
 		const int32 ObjectArraySize = std::max({
 			ObjectsArrayLayout.ObjectsOffset + sizeof(void*),
 			ObjectsArrayLayout.MaxElementsOffset + sizeof(void*),
@@ -3883,7 +3886,7 @@ R"({
 
 		// Start class 'TUObjectArray'
 		PredefinedStruct TUObjectArray = PredefinedStruct{
-			.UniqueName = "TUObjectArray", .Size = ObjectArraySize, .Alignment = alignof(void*), .bUseExplictAlignment = false, .bIsFinal = true, .bIsClass = true, .bIsUnion = false, .Super = nullptr
+			.UniqueName = "TUObjectArray", .Size = ObjectArraySize, .Alignment = ObjectArrayAlignment, .bUseExplictAlignment = false, .bIsFinal = true, .bIsClass = true, .bIsUnion = false, .Super = nullptr
 		};
 
 		TUObjectArray.Properties =
@@ -3966,7 +3969,14 @@ R"({
 		};
 
 		SortMembers(TUObjectArray.Properties);
+
+		if (bRequiresPacking)
+			BasicHpp << std::format("#pragma pack(push, 0x{:X})\n", ObjectArrayAlignment);
+
 		GenerateStruct(&TUObjectArray, BasicHpp, BasicCpp, BasicHpp, AssertionsFile);
+
+		if (bRequiresPacking)
+			BasicHpp << "#pragma pack(pop)\n";
 	}
 	// End class 'TUObjectArray'
 


### PR DESCRIPTION
## Summary

- add an alternate chunked `FUObjectArray` layout used by UE 5.7
- resolve the UE 5.7 `FFieldClass` member reorder from the detected `CastFlags`/`SuperClass` relationship
- leave legacy and case-preserving layouts unchanged

Closes #554.

## Root cause

The object-array scanner only tested the standard UE4.21-UE5.7 layout. The affected UE 5.7 build keeps the `GUObjectArray` root but places `Objects`, element counts, and chunk counts at different relative offsets, so automatic discovery rejected an otherwise valid array.

UE 5.7 also places `ClassFlags` before `Id`, with `CastFlags` directly followed by `SuperClass`. Dumper-7 already locates `CastFlags` dynamically, but the remaining hardcoded offsets produced overlapping `CastFlags`/`ClassFlags` members in the generated SDK.

## Impact

The scanner can now recognize this UE 5.7 object-array variant without a game-specific RVA or manual `ObjectArray::Init` override. Generated `FFieldClass` definitions use the detected UE 5.7 order while retaining the legacy layouts.

## Validation

- built Dumper-7 Release x64 successfully with MSVC (`v145` toolset override)
- live-tested against UE 5.7.4: automatic discovery found the `GUObjectArray` root and enumerated 354,075 objects
- generated C++ SDK, `.usmap`, IDA mapping, and Dumpspace output successfully
- compiled the generated `Basic.cpp`, `CoreUObject_functions.cpp`, and `Engine_functions.cpp` together with an SDK consumer TU under MSVC
- verified the generated `FFieldClass` layout as `Name +0x00`, `ClassFlags +0x08`, `Id +0x10`, `CastFlags +0x18`, `SuperClass +0x20`

## Compatibility note

The new object-array candidate is appended after every existing candidate, preserving their original priority. The `FFieldClass` fixup only runs for the exact reordered relationship; legacy offsets remain unchanged. PR #545 covers the separate UE 5.8 extended `FFieldClass` representation and may overlap in `Offsets.cpp`; the UE 5.7 reorder here remains distinct.
