### PR TITLE
Add IsValid function to FWeakObjectPtr and use it in Get function (Fix #558)

### DIFF
--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -4884,7 +4884,8 @@ R"({
 			.CustomComment = "",
 			.ReturnType = "class UObject*", .NameWithParams = "Get()", .Body =
 R"({
-	if (!IsValid()) return nullptr;
+	if (!IsValid())
+		return nullptr;
 
 	return UObject::GObjects->GetByIndex(ObjectIndex);
 })",

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -4874,8 +4874,18 @@ R"({
 	{
 		PredefinedFunction {
 			.CustomComment = "",
+			.ReturnType = "bool", .NameWithParams = "IsValid()", .Body =
+R"({
+	return ObjectIndex > 0 || (ObjectSerialNumber > 0 && ObjectIndex >= 0);
+})",
+			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = false
+		},
+		PredefinedFunction {
+			.CustomComment = "",
 			.ReturnType = "class UObject*", .NameWithParams = "Get()", .Body =
 R"({
+	if (!IsValid()) return nullptr;
+
 	return UObject::GObjects->GetByIndex(ObjectIndex);
 })",
 			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = false


### PR DESCRIPTION
Fixes #558

The `IsValid()` function is my interpretation of the following code in UE source, which is used in `FWeakObjectPtr::Internal_GetObjectItem` function:
`InvalidWeakObjectIndex` is `0` with `UE_WEAKOBJECTPTR_ZEROINIT_FIX` enabled, otherwise `-1`.
````cpp
if (ObjectSerialNumber == 0)
{
#if UE_WEAKOBJECTPTR_ZEROINIT_FIX
	checkSlow(ObjectIndex == InvalidWeakObjectIndex); // otherwise this is a corrupted weak pointer
#else
	checkSlow(ObjectIndex == 0 || ObjectIndex == -1); // otherwise this is a corrupted weak pointer
#endif

	return nullptr;
}

if (ObjectIndex < 0)
{
	return nullptr;
}
```