### PR TITLE
Add IsValid function to FWeakObjectPtr and use it in Get function (Fix #558)

### DIFF
--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -4876,7 +4876,7 @@ R"({
 			.CustomComment = "",
 			.ReturnType = "bool", .NameWithParams = "IsValid()", .Body =
 R"({
-	return ObjectIndex > 0 || (ObjectSerialNumber > 0 && ObjectIndex >= 0);
+	return ObjectIndex > 0;
 })",
 			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = false
 		},

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -4884,7 +4884,8 @@ R"({
 			.CustomComment = "",
 			.ReturnType = "class UObject*", .NameWithParams = "Get()", .Body =
 R"({
-	if (!IsValid()) return nullptr;
+	if (!IsValid())
+		return nullptr;
 
 	return UObject::GObjects->GetByIndex(ObjectIndex);
 })",

--- a/Dumper/Generator/Private/Generators/CppGenerator.cpp
+++ b/Dumper/Generator/Private/Generators/CppGenerator.cpp
@@ -4874,8 +4874,18 @@ R"({
 	{
 		PredefinedFunction {
 			.CustomComment = "",
+			.ReturnType = "bool", .NameWithParams = "IsValid()", .Body =
+R"({
+	return ObjectIndex > 0 || (ObjectSerialNumber > 0 && ObjectIndex >= 0);
+})",
+			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = false
+		},
+		PredefinedFunction {
+			.CustomComment = "",
 			.ReturnType = "class UObject*", .NameWithParams = "Get()", .Body =
 R"({
+	if (!IsValid()) return nullptr;
+
 	return UObject::GObjects->GetByIndex(ObjectIndex);
 })",
 			.bIsStatic = false, .bIsConst = true, .bIsBodyInline = false


### PR DESCRIPTION
Since you've closed #560 without merging it to main, I guess I can just create a new PR with the same commits.  
I decided that checking for `ObjectIndex > 0` is enough.  
The Get() function just uses `UObject::GObjects->GetByIndex(ObjectIndex)` anyway and I don't see in which scenario an object on Index 0 would be a "valid" object, since the first object in the GObjects array is always the "Package."
